### PR TITLE
docs: document verified self-evolution operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <h1 align="center">✨ OpenKyrozen ✨</h1>
 <p align="center"><strong>Self‑learning AI Agent — DeepSeek · OpenAI · Claude · Gemini · Ollama</strong></p>
-<p align="center">A terminal-native, fully autonomous AI agent that <em>learns from every interaction</em>,<br>operates your filesystem, manages git, fixes bugs, and improves itself over time.</p>
+<p align="center">A terminal-native AI agent that <em>learns from verified outcomes</em>,<br>operates your filesystem, manages git, fixes bugs, and improves itself over time.</p>
 
 <p align="center">
   🌐 <strong>English</strong> ·
@@ -37,13 +37,14 @@
 - [🛠 Tools Reference](#-tools-reference)
   - [File & System](#file--system)
   - [Web](#web)
-  - [Git](#git-15-tools)
+  - [Git](#git-14-tools)
   - [Memory](#memory)
 - [🧠 Dedicated Workflows](#-dedicated-workflows)
   - [Bug fixing](#bug-fixing-6-step-protocol)
   - [Git operations](#git-operations-safety-first)
   - [Complex tasks](#complex-tasks-never-stops-early)
 - [🧬 Self-Learning System](#-self-learning-system)
+  - [Operational self-evolution and memory guide](docs/self-evolution.md)
 - [🌐 Web UI & REST API](#-web-ui--rest-api)
 - [🔌 Plugin System](#-plugin-system)
 - [🔐 Security](#-security)
@@ -59,7 +60,7 @@
 
 OpenKyrozen is a **self-learning AI agent** that runs in your terminal. Unlike a typical chatbot, it:
 
-- **Uses 26 built-in tools** — read/write files, execute shell commands, search the web, manage git repositories
+- **Uses 31 runtime tools** — 29 base file/shell/web/git/browser actions plus two SQLite memory actions
 - **Learns continuously** — background learning creates evidence-backed proposals and only promotes repeated or validated improvements
 - **Works with any LLM** — DeepSeek, OpenAI, Claude, Gemini, or local Ollama models
 - **Runs on any OS** — macOS, Linux, and Windows (with automatic terminal capability detection)
@@ -149,6 +150,15 @@ Kyrozen will:
 | `/learn` | Immediately scan project files into memory |
 | `/forget` | Show recent learnings; `/forget keyword` to delete bad learnings |
 | `/update` | Pull the latest version from git |
+| `/agent auto\|coder\|researcher` | Choose automatic routing or an isolated learning profile |
+| `/learning status [profile]` | Show candidate, canary, active, retired, and rolled-back artifacts |
+| `/learning metrics [profile]` | Show verified completion, corrections, errors, cost, and latency metrics |
+| `/learning evidence <id>` | Print the proof card, replay, applicability, and outcome receipts |
+| `/learning explain <id>` | Print the complete proposal record |
+| `/learning replay <id>` | Explain the API-only paired replay workflow (does not execute commands) |
+| `/learning rollback <id>` | Roll back a learned artifact or proposal |
+| `/memory why <claim-id>` | Inspect a typed claim and its provenance |
+| `/memory forget <claim-id>` | Forget a claim and deactivate solely dependent learned artifacts |
 | `/self-learning` | Toggle individual self-learning features on/off |
 
 ### Web UI mode
@@ -191,7 +201,7 @@ User Input
          │  Response + tool calls
          ▼
 ┌─────────────────┐
-│  Tool Executor   │──► 26 built-in tools (file I/O, shell, git, web, memory)
+│  Tool Executor   │──► 31 runtime tools (file I/O, shell, git, web, memory, browser)
 └────────┬────────┘
          │  Tool results fed back to LLM
          │  (up to 50 tool-call rounds per turn)
@@ -249,7 +259,7 @@ If the primary provider fails, Kyrozen automatically falls back through a chain 
 
 ## 🛠 Tools Reference
 
-All 26 tools accept a plain-string `args` field in a JSON action block:
+All 31 runtime tools accept a plain-string `args` field in a JSON action block:
 
 ```json
 {"action": "read_file", "args": "README.md"}
@@ -275,7 +285,7 @@ Short aliases work too — `bash`, `cmd`, `sh` → `run_cmd`; `status`, `diff`, 
 | `search_web` | Internet search (Google → DDG → Wikipedia) | `"latest Python release"` |
 | `read_webpage` | Fetch URL text content | `"https://example.com"` |
 
-### Git (15 tools)
+### Git (14 tools)
 
 | Tool | What it does |
 |------|-------------|
@@ -341,21 +351,21 @@ For multi-step work (refactors, project generators, codebase audits):
 
 ## 🧬 Profile-scoped self-evolution
 
-OpenKyrozen learns reusable policies and skills only from completed multi-step work, explicit corrections, or verified failures. Learned artifacts are isolated to either the `coder` or `researcher` profile; the `reviewer` can propose one bounded canary after 30 seconds idle but never learns its own behavior.
+OpenKyrozen learns reusable policies and skills only from completed multi-step work, explicit corrections, or verified failures. Learned artifacts are isolated to either the `coder` or `researcher` profile; the `reviewer` can propose one bounded canary during idle review but never learns its own behavior. The background loop waits for at least 60 seconds without user interaction (and each review candidate must be at least 30 seconds old).
 
 ### How it works
 
 Every run records its profile, task signature, tool/error receipts, acceptance evidence, latency, and tokens in SQLite. Matching is deterministic and injects at most three artifacts (8,000 characters total), including at most one canary. A canary promotes only after two distinct verified successes and a non-regressing paired shadow replay; one linked correction, or two verified failures among its last five active uses, rolls it back to its predecessor. Learned artifacts cannot add permissions or dynamic tools, and user/bundled/plugin skills are immutable to evolution.
 
-Use `/agent auto|coder|researcher` to control routing. `/learning status [profile]`, `/learning metrics [profile]`, `/learning evidence <id>`, `/learning explain <id>`, and `/learning rollback <id>` expose lifecycle state and proof. Shadow replay accepts paired frozen results through the authenticated API and never executes replay commands. Project indexing remains separate knowledge ingestion.
+Use `/agent auto|coder|researcher` to control routing. `/learning status [profile]`, `/learning metrics [profile]`, `/learning evidence <id>`, `/learning explain <id>`, `/learning replay <id>`, and `/learning rollback <id>` expose lifecycle state and proof. The terminal replay command is informational; paired frozen results are submitted through the authenticated API, which never executes replay commands. Project indexing remains separate knowledge ingestion. See the [self-evolution and memory operations guide](docs/self-evolution.md) for verified workflows and request examples.
 
-Inferred facts and preferences remain candidates until repeated independent evidence supports them. Explicit owner claims activate immediately. Typed global, profile, project, and task scopes resolve deterministically; `/memory why <id>` explains a claim and `/memory forget <id>` removes it together with solely dependent learned behavior.
+Inferred facts and preferences remain candidates until repeated independent evidence supports them. Explicit owner claims activate immediately. Typed global, profile, project, task, speaker, audience, and channel scopes resolve deterministically; `/memory why <id>` explains a claim and `/memory forget <id>` removes it together with solely dependent learned behavior.
 
 Selection ranks relevant guidance by verified utility per context character and avoids artifact pairs with repeated verified failures. Paired omission trials can retire guidance only when removing it does not reduce verified completion; retirement is reversible and preserves the learned artifact pre-image.
 
 Learned guidance is bound to the provider/model family that produced its evidence unless paired replay validates it across models. Verifier reliability, evidence-adaptive review priority, and a user-owned `KYROZEN_LEARNING_CONSTITUTION` file constrain evolution. Redacted experience capsules are portable JSON evidence, but imports always remain inactive candidates until local validation.
 
-Multi-party claims distinguish attributed beliefs, private facts, and group agreements. Speaker, audience, channel, and visibility checks run before recall; private claims require the current authenticated speaker context. Chat responses include a memory receipt listing the claim IDs and speakers that affected the turn, and `benchmarks/multi_party_memory.jsonl` provides frozen leakage, update, ambiguity, and audience cases.
+Multi-party claims distinguish attributed beliefs, private facts, and group agreements. Speaker, audience, channel, and visibility checks run before recall; private claims require the authenticated request actor, not a client-supplied speaker label. Chat responses include a memory receipt listing the claim IDs and speakers that affected the turn, and `benchmarks/multi_party_memory.jsonl` provides frozen leakage, update, ambiguity, and audience cases.
 
 ### Memory storage
 
@@ -401,10 +411,10 @@ KYROZEN_SERVER_TOKEN=change-me python server.py --host 0.0.0.0 --port 8000
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/` | Dark-themed chat web UI |
-| `POST` | `/api/chat` | Send a message, get JSON response |
-| `POST` | `/api/chat/stream` | SSE streaming chat |
+| `POST` | `/api/chat` | Send a message with optional `profile`, `speaker`, `audience`, and `channel`; returns a memory receipt |
+| `POST` | `/api/chat/stream` | SSE streaming chat with the same optional profile and memory context |
 | `GET` | `/api/memory?q=keyword` | Search stored memories |
-| `GET` | `/api/v2/memory?q=keyword` | Structured memory search with provenance and scope |
+| `GET` | `/api/v2/memory?q=keyword&speaker=...&audience=...&channel=...` | Structured memory search with provenance and party scope |
 | `GET/POST` | `/api/v2/tasks` | Durable task listing and creation |
 | `GET` | `/api/v2/learning` | Learning proposal status |
 | `GET` | `/api/v2/learning/metrics?profile=...` | Profile completion, correction, error, tool, token, and latency metrics |
@@ -417,8 +427,8 @@ KYROZEN_SERVER_TOKEN=change-me python server.py --host 0.0.0.0 --port 8000
 | `POST` | `/api/v2/learning/capsules` | Import a capsule as an inactive candidate |
 | `GET` | `/api/v2/learning/constitution` | Inspect the immutable user-owned learning policy |
 | `POST` | `/api/v2/learning/{id}/rollback` | Roll back an activated proposal |
-| `GET/POST` | `/api/v2/memory/claims` | List or create typed, attributed memory claims |
-| `GET/DELETE` | `/api/v2/memory/claims/{id}` | Explain or dependency-completely forget a claim |
+| `GET/POST` | `/api/v2/memory/claims` | List or create typed, attributed memory claims; filter with `speaker`, `audience`, and `channel` |
+| `GET/DELETE` | `/api/v2/memory/claims/{id}` | Explain or dependency-completely forget a claim with party filters |
 | `GET` | `/api/v2/events` | Auditable runtime, task, session, and learning events |
 | `GET/POST` | `/api/v2/schedules` | Durable interval and one-shot Gateway jobs |
 | `POST` | `/api/v2/schedules/{id}/disable` | Disable a scheduled job |
@@ -599,9 +609,9 @@ pip install .[all]              # + Claude + Gemini + web
 ```
 OpenKyrozen/
 ├── main.py              # Core agent loop, self-learning, chat turn logic
-├── tools.py             # 26 built-in tools (file, shell, git, web)
+├── tools.py             # 29 base tools; main.py adds two memory actions
 ├── providers.py         # Multi-LLM abstraction (5 providers + fallback)
-├── memory.py            # ChromaDB-backed vector memory
+├── memory.py            # SQLite memory with optional rebuildable Chroma index
 ├── server.py            # FastAPI web server + REST API + chat UI
 ├── pyproject.toml       # pip package configuration
 ├── Dockerfile           # Docker image definition

--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -1,0 +1,213 @@
+# Self-evolution and memory operations
+
+This is the operator guide for the merged self-evolution and multi-party memory
+features. It records behavior that is callable today, not a promise about
+future learning. The verification below was run on `main` at `51d0bce` on
+2026-09-03.
+
+## Verified surface
+
+| Surface | Current behavior | Verification |
+| --- | --- | --- |
+| Profile routing | `auto` routes normal requests to `coder` or `researcher`; an explicit profile wins. | `tests/test_evolution.py` |
+| Evidence ledger | Runs, tool/error receipts, acceptance evidence, latency, tokens, and artifact hashes are durable SQLite events. | `tests/test_evolution.py`, `tests/test_evolution_robustness.py` |
+| Canary lifecycle | A learned artifact stays a canary until two distinct verified successes and a non-regressing paired replay; correction or repeated verified failures rolls it back. | `tests/test_evolution.py` |
+| Deterministic selection | Matching is profile- and trigger-scoped, with at most three artifacts and 8,000 body characters, including at most one canary. | `tests/test_causal_selection.py` |
+| Retirement | A paired omission trial can retire an artifact only when completion does not regress; restore keeps the pre-image recoverable. | `tests/test_causal_selection.py` |
+| Robustness | Environment/model mismatch, verifier reliability, constitution rules, and inactive capsule imports are enforced. | `tests/test_evolution_robustness.py` |
+| Typed memory | Owner claims, inferred candidates, scope precedence, dependencies, and `/memory why|forget` are available. | `tests/test_memory_claims.py` |
+| Multi-party memory | Attributed beliefs, private facts, and group agreements are filtered by speaker, audience, channel, and visibility; receipts identify speakers whose claims were used. | `tests/test_multi_party_memory.py`, `tests/test_server.py` |
+| Harness-neutral benchmark | Clean/evolved runs and candidate, predecessor, omission, and no-memory ablations export JSON with a claim gate. | `learning_benchmark.py`, `benchmarks/multi_party_memory.jsonl` |
+
+The implementation is local-only. It does not fine-tune weights, synchronize a
+cloud memory, edit harness source, grant capabilities, or create dynamic tools.
+The base `tools.py` registry exposes 29 actions; the terminal runtime adds
+`search_memory` and `check_stored_data`, for 31 runtime actions.
+
+## Terminal workflow
+
+Start the agent with `make run` or `python main.py`. These commands are handled
+by the running terminal session:
+
+| Command | Use |
+| --- | --- |
+| `/agent auto` | Let task terms choose `coder` or `researcher`. |
+| `/agent coder` | Force repository, terminal, and implementation learning. |
+| `/agent researcher` | Force research, analysis, and source-bound writing learning. |
+| `/learning status [coder\|researcher]` | List proposal stage, profile, uses, failures, and predecessor. |
+| `/learning metrics [coder\|researcher]` | Show verified completion, corrections, repeated errors, tool calls, tokens, latency, and near misses. |
+| `/learning evidence <proposal-id>` | Show the proof card, applicability, replay, outcomes, and metrics. |
+| `/learning explain <proposal-id>` | Show the complete proposal record. |
+| `/learning replay <proposal-id>` | Explain the API replay workflow; it never runs a command itself. |
+| `/learning rollback <proposal-id>` | Roll back a learned proposal or its skill version. |
+| `/memory why <claim-id>` | Inspect claim type, scope, authority, dependencies, and status. |
+| `/memory forget <claim-id>` | Forget a claim and deactivate solely dependent learned artifacts/regressions. |
+
+`/learning replay` is intentionally informational because replay results must
+come from a separately sandboxed, frozen run. Submit those results through the
+API below.
+
+## How automatic evolution behaves
+
+1. Each eligible run is recorded under one profile. Completed multi-step runs,
+   explicit corrections, and verified failures may enter review. Provider
+   failures, secret-bearing runs, routine one-step work, and project indexing
+   are excluded from behavioral evolution.
+2. The background loop reviews after at least 60 seconds without user
+   interaction. A reviewer can create at most one bounded `policy` or `skill`
+   canary for the run, or abstain.
+3. Static validation requires the manifest, Markdown sections, size limits,
+   secret redaction, workspace containment, and declared permissions. Learned
+   artifacts cannot add capabilities or dynamic tools.
+4. A matching canary is used at most once per run. Promotion requires two
+   distinct verified successes, no correction or failed use, and a paired
+   candidate-versus-predecessor replay that does not regress.
+5. A verified artifact-linked correction, or two verified failures among its
+   last five uses, rolls the artifact back to its predecessor. Every activation,
+   promotion, retirement, and rollback is recorded as an auditable event.
+
+For coding, a successful tool call is not enough: an acceptance command/test or
+explicit user confirmation is required. For research, requested sources,
+structure, or artifact creation must be observable, or the user must confirm
+success. Otherwise the run remains unverified.
+
+## Web API
+
+Install the web extras and start the server:
+
+```bash
+pip install -e '.[web]'
+KYROZEN_SERVER_TOKEN=change-me python server.py --host 127.0.0.1 --port 8000
+```
+
+Loopback requests may omit the token. Any non-loopback deployment must send
+`Authorization: Bearer <token>` (or `X-Kyrozen-Token`) and should bind to an
+explicit interface.
+
+### Chat and profiles
+
+`profile` is optional; `auto` is the default. Chat context can also carry a
+speaker, audience, and channel. The response includes `memory_receipt` when
+stored claims affected the turn.
+
+```bash
+curl -sS http://127.0.0.1:8000/api/chat \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <token>' \
+  -d '{"message":"Write a sourced migration note", "profile":"researcher", "session_id":"demo", "speaker":"authenticated", "audience":"team", "channel":"chat"}'
+```
+
+The streaming endpoint `/api/chat/stream` accepts the same body and emits the
+receipt as an SSE record when one is available.
+
+### Inspect learning evidence
+
+```bash
+curl -sS 'http://127.0.0.1:8000/api/v2/learning?profile=coder&status=canary' \
+  -H 'Authorization: Bearer <token>'
+curl -sS 'http://127.0.0.1:8000/api/v2/learning/metrics?profile=coder' \
+  -H 'Authorization: Bearer <token>'
+curl -sS 'http://127.0.0.1:8000/api/v2/learning/<proposal-id>/evidence' \
+  -H 'Authorization: Bearer <token>'
+```
+
+Submit a paired shadow replay only after both rows have been executed in a
+side-effect-free sandbox. Candidate and predecessor arrays must be non-empty,
+the same length, and contain identical unique `case_id` values:
+
+```bash
+curl -sS -X POST 'http://127.0.0.1:8000/api/v2/learning/<proposal-id>/replay' \
+  -H 'Content-Type: application/json' -H 'Authorization: Bearer <token>' \
+  -d '{"candidate":[{"case_id":"case-1","verified_success":true,"provider_model":"provider:model-a"}],"predecessor":[{"case_id":"case-1","verified_success":true,"provider_model":"provider:model-a"}]}'
+```
+
+Use `/omission` with matching `with_item` and `without_item` arrays to record a
+candidate omission trial. `/retire` requires a non-regressing trial;
+`/restore` returns a retired artifact to canary; `/rollback` immediately
+restores its predecessor. `/capsule` exports redacted evidence and
+`POST /api/v2/learning/capsules` imports it as an inactive candidate—import
+never activates trust.
+
+### Typed and multi-party claims
+
+Create an attributed belief or group agreement with the claim endpoint:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8000/api/v2/memory/claims \
+  -H 'Content-Type: application/json' -H 'Authorization: Bearer <token>' \
+  -d '{"key":"release date","value":"Monday","claim_type":"attributed_belief","speaker":"alice","visibility":"group","audiences":["ops"],"channel":"release","authority":"owner"}'
+```
+
+The supported claim types are `general`, `attributed_belief`, `private_fact`,
+and `group_agreement`. Filter retrieval before it reaches the model:
+
+```bash
+curl -sS 'http://127.0.0.1:8000/api/v2/memory?q=release%20date&speaker=alice&audience=ops&channel=release' \
+  -H 'Authorization: Bearer <token>'
+curl -sS 'http://127.0.0.1:8000/api/v2/memory/claims?speaker=alice&audience=ops&channel=release' \
+  -H 'Authorization: Bearer <token>'
+```
+
+An attributed belief is always rendered with its speaker and does not resolve
+to an unattributed value when speakers disagree. A private fact requires
+`authority=owner` and is never exposed through unscoped recall. Private API
+claims must name the authenticated request actor: `loopback` for an
+unauthenticated loopback server, or `authenticated` when
+`KYROZEN_SERVER_TOKEN` is enabled. A client-supplied label such as `alice` is
+an attribution, not an authorization grant. Deployments that need distinct
+human identities or group membership must enforce that mapping at their
+authentication or proxy layer.
+
+`GET /api/v2/events?event_type=memory.recalled` shows the receipt payload used
+for a turn. Learning events such as `learning.outcome`,
+`learning.artifact_promoted`, and `learning.artifact_rolled_back` provide the
+corresponding audit trail.
+
+## Benchmark replay
+
+The benchmark runner is harness-neutral and reads one JSON object per case from
+stdin. Each wrapper must emit these fields:
+
+```json
+{"verified_success":true,"corrections":0,"repeated_errors":0,"tool_calls":4,"tokens":1200,"latency":2.4}
+```
+
+Run the frozen multi-party cases with identical clean/evolved settings:
+
+```bash
+python main.py learning benchmark \
+  --cases benchmarks/multi_party_memory.jsonl \
+  --clean-runner './clean-wrapper' \
+  --evolved-runner './evolved-wrapper' \
+  --ablation 'candidate=./candidate-wrapper' \
+  --ablation 'predecessor=./predecessor-wrapper' \
+  --ablation 'omission=./omission-wrapper' \
+  --ablation 'no-memory=./no-memory-wrapper' \
+  --output benchmark.json
+```
+
+The JSON output preserves case order, per-case results, Wilson completion
+intervals, secondary metrics, and ablations. The claim gate is true only when
+completion is non-regressing and a paired secondary improvement is credible;
+OpenKyrozen does not emit a competitor-superiority claim from a tool success or
+an unpaired run.
+
+## Verification and troubleshooting
+
+Run the same local gates used for the merged implementation:
+
+```bash
+make check
+tmpdir=$(mktemp -d /tmp/openkyrozen-check.XXXXXX)
+KYROZEN_DB_PATH="$tmpdir/state.sqlite3" make test
+git diff --check
+```
+
+The last verification on `main` passed 58 tests, the API health/scoping smoke,
+the CLI command-loop smoke, and the five-case multi-party benchmark with four
+ablations (`make check` reports the 29-entry base registry). A new artifact is
+not immediate: wait for an eligible run, at least
+60 seconds of idle time, reviewer evidence, and then the two-success plus
+replay gate. A model or environment mismatch intentionally downgrades an
+artifact to canary. If ChromaDB is unavailable, SQLite remains the durable
+source and keyword recall continues to work.


### PR DESCRIPTION
## Summary
- add an operator guide for the merged self-evolution, typed-memory, multi-party, and benchmark workflows
- document the callable CLI commands, API payloads, lifecycle gates, audit events, and security boundaries
- record the verified main revision and reproducible validation commands
- correct README drift: 31 runtime tools (29 base plus two memory actions), 14 Git tools, SQLite plus optional Chroma, profile/context parameters, and API-only replay

## Scope
Documentation only: `README.md` and `docs/self-evolution.md`. No runtime, dependency, or generated-data changes. The guide explicitly notes current limitations, including the coarse authenticated actor used by the API and the 60-second idle review cadence.

## Validation
- `make check`
- `KYROZEN_DB_PATH=<temporary sqlite path> make test` (58 tests)
- API health/scoping smoke
- CLI command-loop smoke for `/agent`, `/learning metrics`, and `/memory why`
- five-case multi-party benchmark replay with candidate, predecessor, omission, and no-memory ablations
- Markdown fence/link smoke and `git diff --check`

The untracked `AGENTS.md` was preserved.