### PR TITLE
fix: bind private server state to one authenticated actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,16 @@ non-loopback deployment must set `KYROZEN_SERVER_TOKEN` and send it as
 and dynamic tools. Authentication, capability tokens, and command safety checks
 still apply.
 
+The Web/MCP server is intentionally a **single-user deployment**. One
+`KYROZEN_SERVER_TOKEN` represents the one owner of that server's private
+memories, tasks, events, schedules, and learning state; request JSON cannot
+choose another private speaker. Loopback and token-authenticated requests use
+the same stable actor. Set `KYROZEN_SERVER_ACTOR` to a stable, non-secret label
+when migrating an existing deployment; otherwise the default actor is `local`.
+Public and group-attributed claims may name other speakers, but private claims
+must belong to the deployment actor. Use separate deployments and databases
+for separate private users.
+
 ### Docker deployment
 
 ```bash

--- a/event_store.py
+++ b/event_store.py
@@ -210,9 +210,13 @@ class EventStore:
         return event_id
 
     def list_events(self, event_type: str | None = None, *, limit: int = 100,
-                    workspace_id: str = "default", session_id: str | None = None) -> list[dict[str, Any]]:
+                    workspace_id: str = "default", session_id: str | None = None,
+                    user_id: str | None = None) -> list[dict[str, Any]]:
         clauses = ["workspace_id=?"]
         params: list[Any] = [workspace_id]
+        if user_id is not None:
+            clauses.append("user_id=?")
+            params.append(user_id)
         if event_type:
             clauses.append("event_type=?")
             params.append(event_type)
@@ -227,12 +231,19 @@ class EventStore:
             ).fetchall()
         return [dict(row, payload=self._loads(row["payload"], {})) for row in rows]
 
-    def list_sessions(self, *, workspace_id: str = "default", limit: int = 100) -> list[dict[str, Any]]:
+    def list_sessions(self, *, workspace_id: str = "default", limit: int = 100,
+                      user_id: str | None = None) -> list[dict[str, Any]]:
+        clauses = ["workspace_id=?", "session_id IS NOT NULL"]
+        params: list[Any] = [workspace_id]
+        if user_id is not None:
+            clauses.append("user_id=?")
+            params.append(user_id)
+        params.append(max(1, min(limit, 1000)))
         with self.connection() as db:
             rows = db.execute(
                 "SELECT session_id, MAX(created_at) AS updated_at, COUNT(*) AS event_count FROM events "
-                "WHERE workspace_id=? AND session_id IS NOT NULL GROUP BY session_id ORDER BY updated_at DESC LIMIT ?",
-                (workspace_id, max(1, min(limit, 1000))),
+                f"WHERE {' AND '.join(clauses)} GROUP BY session_id ORDER BY updated_at DESC LIMIT ?",
+                params,
             ).fetchall()
         return [dict(row) for row in rows]
 
@@ -269,9 +280,13 @@ class EventStore:
         return memory_id
 
     def list_memories(self, *, kind: str | None = None, status: str | None = "active", limit: int = 100,
-                      workspace_id: str = "default", session_id: str | None = None) -> list[dict[str, Any]]:
+                      workspace_id: str = "default", session_id: str | None = None,
+                      user_id: str | None = None) -> list[dict[str, Any]]:
         clauses = ["workspace_id=?"]
         params: list[Any] = [workspace_id]
+        if user_id is not None:
+            clauses.append("user_id=?")
+            params.append(user_id)
         if status:
             clauses.append("status=?")
             params.append(status)
@@ -289,20 +304,33 @@ class EventStore:
             ).fetchall()
         return [dict(row, source_event_ids=self._loads(row["source_event_ids"], []), metadata=self._loads(row["metadata"], {})) for row in rows]
 
-    def set_memory_status(self, memory_id: str, status: str, *, workspace_id: str = "default") -> bool:
+    def set_memory_status(self, memory_id: str, status: str, *, workspace_id: str = "default",
+                          user_id: str | None = None) -> bool:
+        clauses = ["id=?", "workspace_id=?"]
+        params: list[Any] = [memory_id, workspace_id]
+        if user_id is not None:
+            clauses.append("user_id=?")
+            params.append(user_id)
+        params[:0] = [status, utc_now()]
         with self._lock, self.connection() as db:
             return db.execute(
-                "UPDATE memories SET status=?,updated_at=? WHERE id=? AND workspace_id=?",
-                (status, utc_now(), memory_id, workspace_id),
+                f"UPDATE memories SET status=?,updated_at=? WHERE {' AND '.join(clauses)}",
+                params,
             ).rowcount == 1
 
-    def delete_memories(self, ids: list[str], *, workspace_id: str = "default") -> int:
+    def delete_memories(self, ids: list[str], *, workspace_id: str = "default",
+                        user_id: str | None = None) -> int:
         ids = [str(item) for item in ids if item]
         if not ids:
             return 0
         placeholders = ",".join("?" for _ in ids)
+        clauses = ["workspace_id=?", f"id IN ({placeholders})"]
+        params: list[Any] = [workspace_id, *ids]
+        if user_id is not None:
+            clauses.insert(1, "user_id=?")
+            params.insert(1, user_id)
         with self._lock, self.connection() as db:
-            cursor = db.execute(f"DELETE FROM memories WHERE workspace_id=? AND id IN ({placeholders})", [workspace_id, *ids])
+            cursor = db.execute(f"DELETE FROM memories WHERE {' AND '.join(clauses)}", params)
             return cursor.rowcount
 
     def upsert_file(self, rel_path: str, content: str, *, user_id: str = "local", workspace_id: str = "default") -> str:
@@ -323,9 +351,15 @@ class EventStore:
             )
         return file_id
 
-    def remove_stale_files(self, valid_paths: set[str], *, workspace_id: str = "default") -> int:
+    def remove_stale_files(self, valid_paths: set[str], *, workspace_id: str = "default",
+                           user_id: str | None = None) -> int:
+        clauses = ["workspace_id=?"]
+        params: list[Any] = [workspace_id]
+        if user_id is not None:
+            clauses.append("user_id=?")
+            params.append(user_id)
         with self._lock, self.connection() as db:
-            rows = db.execute("SELECT id, rel_path FROM files WHERE workspace_id=?", (workspace_id,)).fetchall()
+            rows = db.execute(f"SELECT id, rel_path FROM files WHERE {' AND '.join(clauses)}", params).fetchall()
             stale = [row["id"] for row in rows if row["rel_path"] not in valid_paths]
             if stale:
                 placeholders = ",".join("?" for _ in stale)
@@ -345,9 +379,13 @@ class EventStore:
         return proposal_id
 
     def list_tasks(self, *, workspace_id: str = "default", session_id: str | None = None,
-                   statuses: set[str] | None = None, limit: int = 1000) -> list[dict[str, Any]]:
+                   statuses: set[str] | None = None, limit: int = 1000,
+                   user_id: str | None = None) -> list[dict[str, Any]]:
         clauses = ["workspace_id=?"]
         params: list[Any] = [workspace_id]
+        if user_id is not None:
+            clauses.append("user_id=?")
+            params.append(user_id)
         if session_id is not None:
             clauses.append("session_id=?")
             params.append(session_id)
@@ -394,9 +432,13 @@ class EventStore:
                        (self._json(evidence), utc_now(), proposal_id))
             return len(evidence)
 
-    def list_proposals(self, *, status: str | None = None, workspace_id: str = "default", limit: int = 100) -> list[dict[str, Any]]:
+    def list_proposals(self, *, status: str | None = None, workspace_id: str = "default", limit: int = 100,
+                       user_id: str | None = None) -> list[dict[str, Any]]:
         params: list[Any] = [workspace_id]
         clause = "workspace_id=?"
+        if user_id is not None:
+            clause += " AND user_id=?"
+            params.append(user_id)
         if status:
             clause += " AND status=?"
             params.append(status)
@@ -419,9 +461,12 @@ class EventStore:
         return job_id
 
     def list_schedules(self, *, workspace_id: str = "default", enabled: bool | None = None,
-                       limit: int = 500) -> list[dict[str, Any]]:
+                       limit: int = 500, user_id: str | None = None) -> list[dict[str, Any]]:
         clauses = ["workspace_id=?"]
         params: list[Any] = [workspace_id]
+        if user_id is not None:
+            clauses.append("user_id=?")
+            params.append(user_id)
         if enabled is not None:
             clauses.append("enabled=?")
             params.append(int(enabled))
@@ -430,11 +475,19 @@ class EventStore:
             rows = db.execute(f"SELECT * FROM scheduled_jobs WHERE {' AND '.join(clauses)} ORDER BY next_run_at LIMIT ?", params).fetchall()
         return [dict(row, enabled=bool(row["enabled"]), payload=self._loads(row["payload"], {})) for row in rows]
 
-    def claim_due_schedules(self, *, now: str, workspace_id: str = "default", limit: int = 20) -> list[dict[str, Any]]:
+    def claim_due_schedules(self, *, now: str, workspace_id: str = "default", limit: int = 20,
+                            user_id: str | None = None) -> list[dict[str, Any]]:
+        clauses = ["workspace_id=?"]
+        params: list[Any] = [workspace_id]
+        if user_id is not None:
+            clauses.append("user_id=?")
+            params.append(user_id)
+        clauses.extend(["enabled=1", "next_run_at<=?"])
+        params.extend([now, max(1, min(limit, 100))])
         with self._lock, self.connection() as db:
             rows = db.execute(
-                "SELECT * FROM scheduled_jobs WHERE workspace_id=? AND enabled=1 AND next_run_at<=? ORDER BY next_run_at LIMIT ?",
-                (workspace_id, now, max(1, min(limit, 100))),
+                f"SELECT * FROM scheduled_jobs WHERE {' AND '.join(clauses)} ORDER BY next_run_at LIMIT ?",
+                params,
             ).fetchall()
             claimed: list[dict[str, Any]] = []
             for row in rows:
@@ -448,11 +501,18 @@ class EventStore:
                 claimed.append(dict(row, payload=self._loads(row["payload"], {}), next_run_at=next_run_at))
             return claimed
 
-    def set_schedule_enabled(self, job_id: str, enabled: bool, *, workspace_id: str = "default") -> bool:
+    def set_schedule_enabled(self, job_id: str, enabled: bool, *, workspace_id: str = "default",
+                             user_id: str | None = None) -> bool:
+        clauses = ["id=?", "workspace_id=?"]
+        params: list[Any] = [job_id, workspace_id]
+        if user_id is not None:
+            clauses.append("user_id=?")
+            params.append(user_id)
+        params[:0] = [int(enabled), utc_now()]
         with self._lock, self.connection() as db:
             return db.execute(
-                "UPDATE scheduled_jobs SET enabled=?,updated_at=? WHERE id=? AND workspace_id=?",
-                (int(enabled), utc_now(), job_id, workspace_id),
+                f"UPDATE scheduled_jobs SET enabled=?,updated_at=? WHERE {' AND '.join(clauses)}",
+                params,
             ).rowcount == 1
 
     def upsert_skill(self, *, name: str, version: str, path: str, description: str,

--- a/memory.py
+++ b/memory.py
@@ -116,7 +116,8 @@ class MemoryBank:
 
     def promote_candidate(self, proposal_id: str, *, confidence: float = 0.8,
                           validation: dict[str, Any] | None = None) -> bool:
-        proposals = [p for p in self.store.list_proposals(workspace_id=self.workspace_id) if p["id"] == proposal_id]
+        proposals = [p for p in self.store.list_proposals(workspace_id=self.workspace_id, user_id=self.user_id)
+                     if p["id"] == proposal_id]
         if not proposals:
             return False
         proposal = proposals[0]
@@ -143,7 +144,7 @@ class MemoryBank:
         return file_id
 
     def remove_stale_files(self, valid_paths: set[str]) -> int:
-        removed = self.store.remove_stale_files(valid_paths, workspace_id=self.workspace_id)
+        removed = self.store.remove_stale_files(valid_paths, workspace_id=self.workspace_id, user_id=self.user_id)
         if self._files_collection is not None:
             try:
                 current = self._files_collection.get(include=["metadatas"])
@@ -174,14 +175,15 @@ class MemoryBank:
                 docs = result.get("documents", [[]])
                 if docs and docs[0]:
                     rows = self.store.list_memories(status="active", limit=10000,
-                                                    workspace_id=self.workspace_id, session_id=self.session_id)
+                                                    workspace_id=self.workspace_id, session_id=self.session_id,
+                                                    user_id=self.user_id)
                     metadata = {row["content"]: row.get("metadata", {}) for row in rows}
                     return [doc for doc in docs[0] if not doc.startswith("FILE:") and (
                         include_scoped or metadata.get(doc, {}).get("visibility", "public") == "public")][:limit]
             except Exception as exc:
                 self._last_error = f"memory index query failed: {exc}"
         rows = self.store.list_memories(status="active", limit=10000, workspace_id=self.workspace_id,
-                                        session_id=self.session_id)
+                                        session_id=self.session_id, user_id=self.user_id)
         terms = set(re.findall(r"[\w\u3400-\u9fff]+", query.lower()))
         scored = []
         for row in rows:
@@ -205,7 +207,7 @@ class MemoryBank:
         if not documents:
             return []
         rows = self.store.list_memories(status="active", limit=10000, workspace_id=self.workspace_id,
-                                        session_id=self.session_id)
+                                        session_id=self.session_id, user_id=self.user_id)
         by_content: dict[str, dict[str, Any]] = {}
         for row in rows:
             by_content.setdefault(row["content"], row)
@@ -255,17 +257,17 @@ class MemoryBank:
 
     def get_recent(self, n: int = 10, *, include_scoped: bool = False) -> list[str]:
         rows = self.store.list_memories(status="active", limit=max(1, min(n, 10000)), workspace_id=self.workspace_id,
-                                        session_id=self.session_id)
+                                        session_id=self.session_id, user_id=self.user_id)
         return [row["content"] for row in rows
                 if include_scoped or row.get("metadata", {}).get("visibility", "public") == "public"][:n]
 
     def count_logs(self) -> int:
         return len(self.store.list_memories(status="active", limit=100000, workspace_id=self.workspace_id,
-                                            session_id=self.session_id))
+                                            session_id=self.session_id, user_id=self.user_id))
 
     def get_all(self, limit: int = 2000) -> tuple[list[str], list[str]]:
         rows = self.store.list_memories(status="active", limit=max(1, min(limit, 10000)), workspace_id=self.workspace_id,
-                                        session_id=self.session_id)
+                                        session_id=self.session_id, user_id=self.user_id)
         return [row["id"] for row in rows], [row["content"] for row in rows]
 
     def delete_logs(self, ids: list[str]) -> int:
@@ -274,7 +276,7 @@ class MemoryBank:
             return 0
         known_ids, docs = self.get_all(limit=10000)
         resolved = [item if item in known_ids else known_ids[docs.index(item)] for item in ids if item in known_ids or item in docs]
-        removed = self.store.delete_memories(resolved, workspace_id=self.workspace_id)
+        removed = self.store.delete_memories(resolved, workspace_id=self.workspace_id, user_id=self.user_id)
         if self._collection is not None and resolved:
             try:
                 self._collection.delete(ids=resolved)
@@ -286,7 +288,7 @@ class MemoryBank:
         if self.MAX_LOGS <= 0:
             return
         rows = self.store.list_memories(status="active", limit=self.MAX_LOGS + 100, workspace_id=self.workspace_id,
-                                        session_id=self.session_id)
+                                        session_id=self.session_id, user_id=self.user_id)
         if len(rows) <= self.MAX_LOGS:
             return
         self.delete_logs([row["id"] for row in rows[self.MAX_LOGS:]])
@@ -295,7 +297,7 @@ class MemoryBank:
         if self._collection is None:
             return 0
         rows = self.store.list_memories(status="active", limit=100000, workspace_id=self.workspace_id,
-                                        session_id=self.session_id)
+                                        session_id=self.session_id, user_id=self.user_id)
         for row in rows:
             if row["kind"] != "source":
                 self._index_memory(row["id"], row["content"], kind=row["kind"], status=row["status"])

--- a/scheduler.py
+++ b/scheduler.py
@@ -14,9 +14,11 @@ from event_store import EventStore, utc_now
 class JobScheduler:
     """Polls SQLite and claims due jobs exactly once per process tick."""
 
-    def __init__(self, store: EventStore, *, workspace_id: str = "default", poll_seconds: float = 2.0):
+    def __init__(self, store: EventStore, *, workspace_id: str = "default", user_id: str = "local",
+                 poll_seconds: float = 2.0):
         self.store = store
         self.workspace_id = workspace_id
+        self.user_id = user_id
         self.poll_seconds = max(0.25, poll_seconds)
         self._callbacks: dict[str, Callable[[dict[str, Any]], Any]] = {}
         self._stop = threading.Event()
@@ -32,17 +34,17 @@ class JobScheduler:
         next_run = datetime.now(timezone.utc) + timedelta(seconds=delay_seconds if delay_seconds is not None else interval_seconds)
         return self.store.upsert_schedule(job_id, name, interval_seconds=interval_seconds,
                                            next_run_at=next_run.isoformat(), payload=payload,
-                                           workspace_id=self.workspace_id)
+                                           workspace_id=self.workspace_id, user_id=self.user_id)
 
     def schedule_once(self, name: str, run_at: str, *, payload: dict[str, Any] | None = None,
                       job_id: str | None = None) -> str:
         datetime.fromisoformat(run_at)
         job_id = job_id or f"job_{uuid.uuid4().hex}"
         return self.store.upsert_schedule(job_id, name, run_at=run_at, next_run_at=run_at,
-                                           payload=payload, workspace_id=self.workspace_id)
+                                           payload=payload, workspace_id=self.workspace_id, user_id=self.user_id)
 
     def list_jobs(self, *, enabled: bool | None = None) -> list[dict[str, Any]]:
-        return self.store.list_schedules(workspace_id=self.workspace_id, enabled=enabled)
+        return self.store.list_schedules(workspace_id=self.workspace_id, enabled=enabled, user_id=self.user_id)
 
     def start(self) -> None:
         if self._thread and self._thread.is_alive():
@@ -58,21 +60,21 @@ class JobScheduler:
 
     def tick(self) -> int:
         now = utc_now()
-        jobs = self.store.claim_due_schedules(now=now, workspace_id=self.workspace_id)
+        jobs = self.store.claim_due_schedules(now=now, workspace_id=self.workspace_id, user_id=self.user_id)
         for job in jobs:
             job_type = str(job.get("payload", {}).get("type", "default"))
             callback = self._callbacks.get(job_type)
             if callback is None:
                 self.store.append_event("scheduler.unhandled", {"job_id": job["id"], "type": job_type},
-                                        workspace_id=self.workspace_id)
+                                        user_id=self.user_id, workspace_id=self.workspace_id)
                 continue
             try:
                 callback(job)
                 self.store.append_event("scheduler.completed", {"job_id": job["id"], "type": job_type},
-                                        workspace_id=self.workspace_id)
+                                        user_id=self.user_id, workspace_id=self.workspace_id)
             except Exception as exc:
                 self.store.append_event("scheduler.failed", {"job_id": job["id"], "type": job_type, "error": str(exc)[:1000]},
-                                        workspace_id=self.workspace_id)
+                                        user_id=self.user_id, workspace_id=self.workspace_id)
         return len(jobs)
 
     def _run(self) -> None:

--- a/server.py
+++ b/server.py
@@ -61,6 +61,14 @@ app = FastAPI(
 # ---------------------------------------------------------------------------
 
 _SERVER_TOKEN = os.environ.get("KYROZEN_SERVER_TOKEN", "").strip()
+# A server process is deliberately single-user.  The bearer token authenticates
+# access to this deployment; it is not a multi-user identity provider.  Keep
+# this actor stable across loopback/token access and token rotation so existing
+# private state remains owned by the same deployment user.
+_CONFIGURED_SERVER_ACTOR = os.environ.get("KYROZEN_SERVER_ACTOR", "local").strip()
+_SERVER_ACTOR_ID = (_CONFIGURED_SERVER_ACTOR
+                   if re.fullmatch(r"[A-Za-z0-9_.:@-]{1,64}", _CONFIGURED_SERVER_ACTOR)
+                   else "local")
 _LOCAL_CLIENT_NAMES = {"localhost", "127.0.0.1", "::1", "testclient"}
 
 
@@ -127,7 +135,13 @@ _MAX_SESSION_MESSAGES = 32
 _MAX_MESSAGE_CHARS = 12_000
 _MAX_MEMORY_QUERY_CHARS = 500
 _MAX_MEMORY_RESULTS = 50
-_scheduler = JobScheduler(_agent.memory_bank.store, workspace_id=_agent.memory_bank.workspace_id)
+# The web surface must use the authenticated deployment actor for every
+# durable subsystem.  Request JSON can describe a public/group speaker, but
+# it can never change ownership of private state.
+_agent.memory_bank.user_id = _SERVER_ACTOR_ID
+_agent.tasks.user_id = _SERVER_ACTOR_ID
+_scheduler = JobScheduler(_agent.memory_bank.store, workspace_id=_agent.memory_bank.workspace_id,
+                          user_id=_SERVER_ACTOR_ID)
 
 
 def _run_scheduled_job(job: dict[str, Any]) -> None:
@@ -140,7 +154,7 @@ def _run_scheduled_job(job: dict[str, Any]) -> None:
         return
     if payload.get("type") == "chat":
         session_id = _normalise_session_id(payload.get("session_id"))
-        session = _get_or_create_session(session_id, "scheduler")
+        session = _get_or_create_session(session_id, _SERVER_ACTOR_ID)
         _run_session_chat(session, str(payload.get("message", "")))
         return
     raise ValueError(f"Unknown scheduled job type: {payload.get('type', 'default')}")
@@ -182,7 +196,8 @@ def _normalise_memory_context(speaker: Any, audience: Any, channel: Any) -> tupl
 
 
 def _set_memory_context(session: dict[str, Any], body: dict[str, Any]) -> None:
-    default = session.get("user_id", "local")
+    default = _SERVER_ACTOR_ID
+    session["user_id"] = default
     speaker = _normalise_memory_actor(body.get("speaker"), "speaker", session.get("speaker", default))
     audience = _normalise_memory_actor(body.get("audience"), "audience", session.get("audience", speaker))
     channel = _normalise_memory_actor(body.get("channel"), "channel", session.get("channel", "chat"))
@@ -191,16 +206,23 @@ def _set_memory_context(session: dict[str, Any], body: dict[str, Any]) -> None:
 
 
 def _actor_for_request(request: Request) -> str:
-    """Return a coarse audit actor; user_id is never accepted from JSON."""
-    return "authenticated" if _SERVER_TOKEN else "loopback"
+    """Return the stable single-user deployment actor.
+
+    Authentication is enforced by ``require_api_access``.  This function only
+    maps an already-authorized request to the one owner supported by this
+    server process; no header or JSON field can select another private user.
+    """
+    return _SERVER_ACTOR_ID
 
 
 def _get_or_create_session(session_id: str, user_id: str = "anonymous") -> dict:
+    user_id = _SERVER_ACTOR_ID
     with _chat_lock:
         if session_id not in _sessions:
             persisted = _agent.memory_bank.store.list_events(
                 event_type="session.message", limit=_MAX_SESSION_MESSAGES,
                 workspace_id=_agent.memory_bank.workspace_id, session_id=session_id,
+                user_id=user_id,
             )
             messages = []
             for event in reversed(persisted):
@@ -239,7 +261,7 @@ def _run_session_chat(session: dict[str, Any], message: str) -> str:
         try:
             previous_recall = _agent.memory_bank.store.list_events(
                 "memory.recalled", limit=1, workspace_id=_agent.memory_bank.workspace_id,
-                session_id=session.get("session_id"),
+                session_id=session.get("session_id"), user_id=_SERVER_ACTOR_ID,
             )
             previous_recall_id = previous_recall[0]["id"] if previous_recall else None
             allowed = _allowed_server_tools("web")
@@ -267,7 +289,7 @@ def _run_session_chat(session: dict[str, Any], message: str) -> str:
             session["updated"] = time.time()
             recalls = _agent.memory_bank.store.list_events(
                 "memory.recalled", limit=1, workspace_id=_agent.memory_bank.workspace_id,
-                session_id=_agent.memory_bank.session_id,
+                session_id=_agent.memory_bank.session_id, user_id=_SERVER_ACTOR_ID,
             )
             session["last_memory_receipt"] = (recalls[0]["payload"]
                                               if recalls and recalls[0]["id"] != previous_recall_id else None)
@@ -545,15 +567,18 @@ async def api_v2_memory(request: Request, q: str = "", limit: int = 10, session_
     speaker, audience, channel = _normalise_memory_context(speaker, audience, channel)
     authorized_speakers = {_actor_for_request(request)}
     if q:
-        memory = MemoryBank(_agent.memory_bank.db_path, workspace_id=_agent.memory_bank.workspace_id,
+        memory = MemoryBank(_agent.memory_bank.db_path, user_id=_actor_for_request(request),
+                            workspace_id=_agent.memory_bank.workspace_id,
                             session_id=_normalise_session_id(session_id) if session_id else None)
         results = memory.recall_records(q, n_results=limit, speaker=speaker, audience=audience, channel=channel,
                                         authorized_speakers=authorized_speakers)
     else:
-        memory = MemoryBank(_agent.memory_bank.db_path, workspace_id=_agent.memory_bank.workspace_id,
+        memory = MemoryBank(_agent.memory_bank.db_path, user_id=_actor_for_request(request),
+                            workspace_id=_agent.memory_bank.workspace_id,
                             session_id=_normalise_session_id(session_id) if session_id else None)
         rows = memory.store.list_memories(status="active", limit=limit * 4,
-                                          workspace_id=memory.workspace_id, session_id=memory.session_id)
+                                          workspace_id=memory.workspace_id, session_id=memory.session_id,
+                                          user_id=_actor_for_request(request))
         results = memory.filter_records(rows, speaker=speaker, audience=audience, channel=channel,
                                         authorized_speakers=authorized_speakers)[:limit]
     return {"results": results, "total": memory.count_logs(), "scope": {
@@ -566,7 +591,8 @@ async def api_v2_memory_claims(request: Request, speaker: str | None = None, aud
                                channel: str | None = None):
     speaker, audience, channel = _normalise_memory_context(speaker, audience, channel)
     rows = _agent.memory_bank.store.list_memories(status=None, limit=10000,
-                                                  workspace_id=_agent.memory_bank.workspace_id)
+                                                  workspace_id=_agent.memory_bank.workspace_id,
+                                                  user_id=_actor_for_request(request))
     claims = [row for row in rows if row.get("metadata", {}).get("claim")]
     return {"claims": _agent.memory_bank.filter_records(
         claims, speaker=speaker, audience=audience, channel=channel,
@@ -579,8 +605,11 @@ async def api_v2_create_memory_claim(request: Request):
     body = await request.json()
     if not isinstance(body, dict):
         raise HTTPException(400, "JSON object required")
-    if body.get("claim_type") == "private_fact" and body.get("speaker") != _actor_for_request(request):
+    actor = _actor_for_request(request)
+    if body.get("claim_type") == "private_fact" and body.get("speaker") not in {None, actor}:
         raise HTTPException(403, "Private claims must belong to the authenticated speaker")
+    if body.get("claim_type") == "private_fact":
+        body["speaker"] = actor
     try:
         return _agent.learning_engine.remember_claim(
             key=body.get("key", ""), value=body.get("value", ""), kind=body.get("kind", "fact"),
@@ -618,8 +647,10 @@ async def api_v2_memory_forget_claim(claim_id: str):
 @app.get("/api/v2/tasks", dependencies=[Depends(require_api_access)])
 async def api_v2_tasks(session_id: str | None = None):
     session = _normalise_session_id(session_id) if session_id else None
-    manager = TaskManager(_agent.memory_bank.store, workspace_id=_agent.memory_bank.workspace_id, session_id=session)
-    return {"tasks": manager.store.list_tasks(workspace_id=manager.workspace_id, session_id=session)}
+    manager = TaskManager(_agent.memory_bank.store, workspace_id=_agent.memory_bank.workspace_id,
+                          session_id=session, user_id=_SERVER_ACTOR_ID)
+    return {"tasks": manager.store.list_tasks(workspace_id=manager.workspace_id, session_id=session,
+                                                user_id=_SERVER_ACTOR_ID)}
 
 
 @app.post("/api/v2/tasks", dependencies=[Depends(require_api_access)])
@@ -628,7 +659,8 @@ async def api_v2_create_task(request: Request):
     if not isinstance(body, dict) or not str(body.get("description", "")).strip():
         raise HTTPException(400, "description is required")
     session = _normalise_session_id(body.get("session_id"))
-    manager = TaskManager(_agent.memory_bank.store, workspace_id=_agent.memory_bank.workspace_id, session_id=session)
+    manager = TaskManager(_agent.memory_bank.store, workspace_id=_agent.memory_bank.workspace_id,
+                          session_id=session, user_id=_SERVER_ACTOR_ID)
     index = manager.add_task(
         str(body["description"]),
         dependencies=body.get("dependencies") if isinstance(body.get("dependencies"), list) else None,
@@ -739,7 +771,7 @@ async def api_v2_events(event_type: str | None = None, session_id: str | None = 
     session = _normalise_session_id(session_id) if session_id else None
     return {"events": _agent.memory_bank.store.list_events(
         event_type=event_type, limit=max(1, min(limit, 500)),
-        workspace_id=_agent.memory_bank.workspace_id, session_id=session,
+        workspace_id=_agent.memory_bank.workspace_id, session_id=session, user_id=_SERVER_ACTOR_ID,
     )}
 
 
@@ -747,13 +779,14 @@ async def api_v2_events(event_type: str | None = None, session_id: str | None = 
 async def api_v2_sessions(limit: int = 100):
     return {"sessions": _agent.memory_bank.store.list_sessions(
         workspace_id=_agent.memory_bank.workspace_id, limit=max(1, min(limit, 500)),
+        user_id=_SERVER_ACTOR_ID,
     )}
 
 
 @app.get("/api/v2/sessions/{session_id}", dependencies=[Depends(require_api_access)])
 async def api_v2_session(session_id: str):
     session_id = _normalise_session_id(session_id)
-    session = _get_or_create_session(session_id, "authenticated")
+    session = _get_or_create_session(session_id, _SERVER_ACTOR_ID)
     return {"session_id": session_id, "messages": session["messages"], "updated": session.get("updated")}
 
 
@@ -787,7 +820,8 @@ async def api_v2_create_schedule(request: Request):
 
 @app.post("/api/v2/schedules/{job_id}/disable", dependencies=[Depends(require_api_access)])
 async def api_v2_disable_schedule(job_id: str):
-    if not _agent.memory_bank.store.set_schedule_enabled(job_id, False, workspace_id=_agent.memory_bank.workspace_id):
+    if not _agent.memory_bank.store.set_schedule_enabled(job_id, False, workspace_id=_agent.memory_bank.workspace_id,
+                                                         user_id=_SERVER_ACTOR_ID):
         raise HTTPException(404, "Schedule not found")
     return {"status": "disabled", "job_id": job_id}
 
@@ -917,7 +951,7 @@ async def mcp_endpoint(request: Request):
         if not msg:
             raise HTTPException(400, "Empty message")
         session_id = _normalise_session_id(params.get("session_id"))
-        session = _get_or_create_session(session_id, "authenticated")
+        session = _get_or_create_session(session_id, _SERVER_ACTOR_ID)
         reply = _run_session_chat(session, msg)
         return {"jsonrpc": "2.0", "result": {"content": reply, "session_id": session_id}}
     else:

--- a/tests/test_multi_party_memory.py
+++ b/tests/test_multi_party_memory.py
@@ -80,6 +80,17 @@ class MultiPartyMemoryTests(unittest.TestCase):
         receipt = self.memory.store.list_events("memory.recalled", workspace_id="project", session_id="session")[0]
         self.assertEqual(receipt["payload"]["attributions"][0]["speaker"], "alice")
 
+    def test_memory_bank_reads_are_scoped_to_its_user(self):
+        alice = MemoryBank(self.memory.db_path, user_id="alice", workspace_id="project", session_id="alice-session")
+        bob = MemoryBank(self.memory.db_path, user_id="bob", workspace_id="project", session_id="bob-session")
+        memory_id = alice.add_log(
+            "Private fact from alice — medical note: diagnosis-8x",
+            kind="fact", metadata={"visibility": "private", "speaker": "alice", "claim_type": "private_fact"},
+        )
+        self.assertEqual(alice.get_all()[0], [memory_id])
+        self.assertEqual(bob.get_all()[0], [])
+        self.assertEqual(bob.store.list_events(workspace_id="project", user_id="bob"), [])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -51,9 +51,10 @@ class ServerBoundaryTests(unittest.TestCase):
         self.assertIs(server._agent.tasks.tasks, original_tasks)
 
     def test_memory_context_does_not_trust_a_claimed_speaker(self):
-        session = {"user_id": "authenticated"}
+        session = {"user_id": "spoofed-client-value"}
         server._set_memory_context(session, {"speaker": "alice", "audience": "team", "channel": "project"})
-        self.assertEqual(session["authorized_speakers"], ["authenticated"])
+        self.assertEqual(session["user_id"], server._SERVER_ACTOR_ID)
+        self.assertEqual(session["authorized_speakers"], [server._SERVER_ACTOR_ID])
         self.assertEqual(session["audience"], "team")
         with self.assertRaises(HTTPException):
             server._set_memory_context(session, {"speaker": "alice/../../bob"})
@@ -63,13 +64,31 @@ class ServerBoundaryTests(unittest.TestCase):
         claim = {"key": "private-api-check", "value": "hidden-7x", "claim_type": "private_fact",
                  "speaker": "alice", "authority": "owner"}
         self.assertEqual(client.post("/api/v2/memory/claims", json=claim).status_code, 403)
-        claim["speaker"] = "loopback"
+        claim["speaker"] = server._SERVER_ACTOR_ID
         created = client.post("/api/v2/memory/claims", json=claim)
         self.assertEqual(created.status_code, 200, created.text)
         hidden = client.get("/api/v2/memory/claims", params={"speaker": "alice"}).json()["claims"]
-        visible = client.get("/api/v2/memory/claims", params={"speaker": "loopback"}).json()["claims"]
+        visible = client.get("/api/v2/memory/claims",
+                             params={"speaker": server._SERVER_ACTOR_ID}).json()["claims"]
         self.assertNotIn(created.json()["memory_id"], [item["id"] for item in hidden])
         self.assertIn(created.json()["memory_id"], [item["id"] for item in visible])
+
+    def test_private_claim_without_speaker_is_bound_to_deployment_actor(self):
+        client = TestClient(server.app)
+        response = client.post("/api/v2/memory/claims", json={
+            "key": "private-api-default", "value": "deployment-owned", "claim_type": "private_fact",
+            "authority": "owner",
+        })
+        self.assertEqual(response.status_code, 200, response.text)
+        claim_id = response.json()["memory_id"]
+        visible = client.get("/api/v2/memory/claims",
+                             params={"speaker": server._SERVER_ACTOR_ID}).json()["claims"]
+        self.assertIn(claim_id, [item["id"] for item in visible])
+
+    def test_server_actor_is_stable_across_authentication_modes(self):
+        self.assertEqual(server._actor_for_request(None), server._SERVER_ACTOR_ID)
+        self.assertEqual(server._get_or_create_session("single-user-test", "alice")["user_id"],
+                         server._SERVER_ACTOR_ID)
 
     def test_profile_validation(self):
         self.assertEqual(server._normalise_profile(None), "auto")


### PR DESCRIPTION
Fixes #27

## What changed
- bind Web/MCP private state to one stable deployment actor
- reject client-supplied private speakers and scope durable reads by user
- document the explicit single-user deployment model

## Validation
- make test
- make check
- make lint
- real TestClient + temporary SQLite private-claim/session smoke test

No secrets or runtime data included.