### PR TITLE
fix: resolve shell commands from the active Python environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install:
 	@echo "Creating virtual environment with $(PYTHON)..."
 	@command -v $(PYTHON) >/dev/null 2>&1 || { echo "Error: $(PYTHON) not found. Install Python 3.12 first."; exit 1; }
 	$(PYTHON) -m venv venv
-	. venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt
+	./venv/bin/python -m pip install --upgrade pip && ./venv/bin/python -m pip install -r requirements.txt
 	@echo ""
 	@echo "OpenKyrozen installed. Run 'make run' or 'python main.py'"
 
@@ -31,14 +31,14 @@ debug:
 
 init:
 	@command -v $(PYTHON) >/dev/null 2>&1 || { echo "Error: venv requires $(PYTHON). Run 'make install' first."; exit 1; }
-	. venv/bin/activate && python main.py --init
+	$(VENV_PYTHON) main.py --init
 
 # Upgrade the venv to use a different Python version (e.g. after macOS upgrade)
 reinstall:
 	@echo "Rebuilding venv with $(PYTHON)..."
 	rm -rf venv
 	$(PYTHON) -m venv venv
-	. venv/bin/activate && pip install --upgrade pip && pip install -r requirements.txt
+	./venv/bin/python -m pip install --upgrade pip && ./venv/bin/python -m pip install -r requirements.txt
 
 clean:
 	rm -rf venv chroma_memory __pycache__

--- a/README.md
+++ b/README.md
@@ -278,6 +278,11 @@ Short aliases work too — `bash`, `cmd`, `sh` → `run_cmd`; `status`, `diff`, 
 | `find_files` | Glob-based file search | `"*.py\|."` |
 | `run_cmd` | Execute shell command | `"python --version"` |
 
+`run_cmd` prepends the `bin` directory of the Python interpreter running
+OpenKyrozen, so bare `python` and `pip` resolve inside the active virtual
+environment even when the parent shell was not activated. Explicit interpreter
+paths such as `/usr/bin/python3` are left unchanged.
+
 ### Web
 
 | Tool | Description | Example |

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,8 +1,11 @@
 import tempfile
 import unittest
+import os
+import sys
+from unittest.mock import patch
 from pathlib import Path
 
-from tools import AVAILABLE_TOOLS, allowed_tool_names, read_file, set_workspace_root, write_file
+from tools import AVAILABLE_TOOLS, allowed_tool_names, read_file, run_cmd, set_workspace_root, write_file
 
 
 class WorkspaceToolTests(unittest.TestCase):
@@ -26,6 +29,16 @@ class WorkspaceToolTests(unittest.TestCase):
         self.assertIn("write_file", workspace)
         self.assertNotIn("git_reset", workspace)
         self.assertIn("git_reset", full)
+
+    def test_run_cmd_resolves_bare_python_from_active_environment(self):
+        with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}, clear=False):
+            result = run_cmd("python -c 'import sys; print(sys.executable)' ")
+        self.assertEqual(Path(result).resolve(), Path(sys.executable).resolve())
+
+    def test_run_cmd_preserves_explicit_interpreter_paths(self):
+        with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}, clear=False):
+            result = run_cmd(f"{sys.executable} -c 'print(\"explicit\")'")
+        self.assertEqual(result, "explicit")
 
 
 if __name__ == "__main__":

--- a/tools.py
+++ b/tools.py
@@ -8,6 +8,7 @@ import re
 import glob
 import tempfile
 import shutil
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -76,6 +77,23 @@ def _is_dangerous(cmd: str) -> bool:
     return bool(_BLOCKED_RE.search(cmd))
 
 
+def _active_command_env() -> dict[str, str]:
+    """Make the interpreter running Kyrozen win bare ``python``/``pip`` lookups."""
+    env = os.environ.copy()
+    # Keep the visible venv ``bin`` directory before the resolved interpreter
+    # target; on macOS a venv executable is commonly a symlink to Homebrew.
+    interpreter_path = Path(sys.executable)
+    interpreter_dir = str(interpreter_path.parent)
+    resolved_dir = str(interpreter_path.resolve().parent)
+    current_path = env.get("PATH", "")
+    path_entries = current_path.split(os.pathsep) if current_path else []
+    for directory in reversed((interpreter_dir, resolved_dir)):
+        if directory and directory not in path_entries:
+            path_entries.insert(0, directory)
+    env["PATH"] = os.pathsep.join(path_entries)
+    return env
+
+
 def write_file(args: str) -> str:
     """
     Write content to a file. Args format: "path|content".
@@ -130,6 +148,7 @@ def run_cmd(args: str) -> str:
             capture_output=True,
             text=True,
             timeout=60,
+            env=_active_command_env(),
         )
         out = result.stdout or ""
         err = result.stderr or ""


### PR DESCRIPTION
Fixes #20

## What changed
- prepend the running interpreter environment to shell tool PATH resolution
- keep explicit interpreter paths untouched
- make install/init use the project interpreter directly
- document the runtime behavior

## Validation
- make test
- make check
- make lint
- run_cmd with PATH=/usr/bin:/bin executed Python from the active venv

No runtime data included.