### PR TITLE
fix: support keyless Ollama and headless startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,13 @@ python main.py
 
 If the primary provider fails, Kyrozen automatically falls back through a chain (e.g., DeepSeek → OpenAI → Claude). Rate-limit errors (HTTP 429) trigger exponential backoff with jitter.
 
+Ollama is keyless: set `KYROZEN_PROVIDER=ollama` and, if needed, point
+`KYROZEN_BASE_URL` at the local OpenAI-compatible endpoint. The Web server
+always initialises in headless mode. If a remote provider has no key, it
+starts in a documented degraded state without reading stdin; configure the
+provider before sending chat requests. The interactive CLI still prompts for
+providers that require credentials.
+
 ---
 
 ## 🛠 Tools Reference

--- a/main.py
+++ b/main.py
@@ -1007,31 +1007,52 @@ def _save_config_key(key: str) -> None:
         console.print(f"[{_WARNING}]Warning: could not save API key to config file.[/{_WARNING}]")
 
 
-def _prompt_and_init_deepseek() -> None:
-    """Detect provider, prompt for API key if needed, initialise the LLM client."""
+def _prompt_and_init_deepseek(*, interactive: bool = True) -> bool:
+    """Detect the provider and initialise the LLM client.
+
+    Ollama is a local, keyless provider.  Headless surfaces pass
+    ``interactive=False`` so a missing remote credential produces a usable
+    degraded process instead of reading stdin or raising during ASGI startup.
+    Interactive CLI setup retains the credential prompt for providers that
+    require one.  The return value reports whether a provider was initialised.
+    """
     global _provider_config, llm_provider, DEEPSEEK_MODEL, DEEPSEEK_MODEL_SIMPLE, DEEPSEEK_MODEL_COMPLEX, MODEL_NAME
 
     _provider_config = detect_provider()
+    llm_provider = None
 
-    # If no API key is stored, prompt the user
+    # Ollama's local OpenAI-compatible endpoint deliberately has no credential.
     if not _provider_config.api_key:
-        console.print(f"\n{_provider_config.provider.title()} API key not set.")
-        env_var = PROVIDER_ENV_VARS.get(_provider_config.provider, "")
-        hint = f" (set {env_var})" if env_var else ""
-        try:
-            key = console.input(
-                f"[bold yellow]Enter your {_provider_config.provider.title()} API key{hint}: [/bold yellow]"
-            ).strip()
-        except (EOFError, KeyboardInterrupt):
-            console.print("\nCancelled.")
-            llm_provider = None
-            sys.exit(0)
-        if not key:
-            console.print("No API key entered – use /quit to exit.")
-            llm_provider = None
-            sys.exit(0)
-        _provider_config.api_key = key
-        save_provider_config_encrypted(_provider_config)
+        if _provider_config.provider == "ollama":
+            console.print("Ollama selected: no API key is required; using the configured local endpoint.")
+        elif not interactive:
+            env_var = PROVIDER_ENV_VARS.get(_provider_config.provider, "")
+            hint = f" Set {env_var} or KYROZEN_API_KEY before sending chat requests." if env_var else ""
+            console.print(
+                f"[yellow]Degraded startup: {_provider_config.provider.title()} API key is not configured."
+                f" Headless mode will not prompt for credentials.{hint}[/yellow]"
+            )
+            DEEPSEEK_MODEL_SIMPLE = _provider_config.model_simple
+            DEEPSEEK_MODEL_COMPLEX = _provider_config.model_complex
+            DEEPSEEK_MODEL = DEEPSEEK_MODEL_SIMPLE
+            MODEL_NAME = f"{_provider_config.provider} ({DEEPSEEK_MODEL_SIMPLE})"
+            return False
+        else:
+            console.print(f"\n{_provider_config.provider.title()} API key not set.")
+            env_var = PROVIDER_ENV_VARS.get(_provider_config.provider, "")
+            hint = f" (set {env_var})" if env_var else ""
+            try:
+                key = console.input(
+                    f"[bold yellow]Enter your {_provider_config.provider.title()} API key{hint}: [/bold yellow]"
+                ).strip()
+            except (EOFError, KeyboardInterrupt):
+                console.print("\nCancelled.")
+                sys.exit(0)
+            if not key:
+                console.print("No API key entered – use /quit to exit.")
+                sys.exit(0)
+            _provider_config.api_key = key
+            save_provider_config_encrypted(_provider_config)
 
     # Set provider-specific env var for subprocesses / SDK auto-detection
     env_var = PROVIDER_ENV_VARS.get(_provider_config.provider, "")
@@ -1052,6 +1073,7 @@ def _prompt_and_init_deepseek() -> None:
     if issues:
         for issue in issues:
             console.print(f"[{_WARNING}]Config: {issue}[/{_WARNING}]")
+    return True
 
 
 DEEPSEEK_MODEL: str = DEEPSEEK_MODEL_SIMPLE

--- a/server.py
+++ b/server.py
@@ -1200,7 +1200,7 @@ async def startup():
     """Initialize the agent on server start."""
     print("[Server] Initializing OpenKyrozen...")
     _agent._set_workspace_root(os.getcwd())
-    _agent._prompt_and_init_deepseek()
+    _agent._prompt_and_init_deepseek(interactive=False)
     if _agent.llm_provider is None:
         print("[Server] WARNING: No LLM provider configured. Set API key env vars.")
     else:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,13 +1,86 @@
 import os
+import asyncio
+import threading
 import unittest
 from unittest.mock import patch
 
 import server
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
+from providers import ProviderConfig
 
 
 class ServerBoundaryTests(unittest.TestCase):
+    def test_ollama_initialization_never_prompts_for_a_key(self):
+        original_config = server._agent._provider_config
+        original_provider = server._agent.llm_provider
+        config = ProviderConfig(provider="ollama", base_url="http://127.0.0.1:11434/v1")
+        try:
+            with patch.object(server._agent, "detect_provider", return_value=config):
+                with patch.object(server._agent, "get_fallback_provider", return_value=object()) as create:
+                    with patch.object(server._agent.console, "input", side_effect=AssertionError("prompted")):
+                        self.assertTrue(server._agent._prompt_and_init_deepseek(interactive=False))
+            create.assert_called_once_with(config)
+            self.assertEqual(server._agent._provider_config.provider, "ollama")
+        finally:
+            server._agent._provider_config = original_config
+            server._agent.llm_provider = original_provider
+
+    def test_headless_missing_remote_key_enters_deterministic_degraded_state(self):
+        original_config = server._agent._provider_config
+        original_provider = server._agent.llm_provider
+        config = ProviderConfig(provider="deepseek", api_key="")
+        try:
+            with patch.object(server._agent, "detect_provider", return_value=config):
+                with patch.object(server._agent.console, "input", side_effect=AssertionError("prompted")):
+                    self.assertFalse(server._agent._prompt_and_init_deepseek(interactive=False))
+            self.assertIsNone(server._agent.llm_provider)
+            self.assertEqual(server._agent._provider_config.provider, "deepseek")
+        finally:
+            server._agent._provider_config = original_config
+            server._agent.llm_provider = original_provider
+
+    def test_interactive_missing_remote_key_still_accepts_a_key(self):
+        original_config = server._agent._provider_config
+        original_provider = server._agent.llm_provider
+        config = ProviderConfig(provider="deepseek", api_key="")
+        try:
+            with patch.object(server._agent, "detect_provider", return_value=config):
+                with patch.object(server._agent.console, "input", return_value="sk-interactive"):
+                    with patch.object(server._agent, "save_provider_config_encrypted"):
+                        with patch.object(server._agent, "get_fallback_provider", return_value=object()):
+                            self.assertTrue(server._agent._prompt_and_init_deepseek(interactive=True))
+            self.assertEqual(server._agent._provider_config.api_key, "sk-interactive")
+        finally:
+            server._agent._provider_config = original_config
+            server._agent.llm_provider = original_provider
+
+    def test_server_startup_initializes_headlessly(self):
+        with patch.object(server._agent, "_prompt_and_init_deepseek") as init_provider:
+            with patch.object(server._agent, "_set_workspace_root"):
+                with patch.object(server._agent, "_load_project_files_into_memory"):
+                    with patch.object(server, "_load_plugins"):
+                        with patch.object(server, "_trigger_hook"):
+                            with patch.object(server._task_worker, "recover", return_value=[]):
+                                with patch.object(server._scheduler, "list_jobs", return_value=[
+                                    {"payload": {"type": "task_worker"}},
+                                ]):
+                                    with patch.object(server._scheduler, "start"):
+                                        errors = []
+
+                                        def run_startup():
+                                            try:
+                                                asyncio.run(server.startup())
+                                            except Exception as exc:  # pragma: no cover - assertion below reports it
+                                                errors.append(exc)
+
+                                        thread = threading.Thread(target=run_startup)
+                                        thread.start()
+                                        thread.join(timeout=5)
+                                        self.assertFalse(thread.is_alive())
+                                        self.assertEqual(errors, [])
+        init_provider.assert_called_once_with(interactive=False)
+
     def test_server_profiles_keep_workspace_tools_and_gate_reset(self):
         workspace = server._allowed_server_tools("mcp")
         self.assertIn("run_cmd", workspace)


### PR DESCRIPTION
Fixes #7

Treat Ollama as a keyless local provider and add an explicit non-interactive initialization mode. The Web server now starts without reading stdin, reports deterministic degraded health when a remote provider is missing credentials, and retains interactive CLI prompting for key-required providers.

Validation:
- `./venv/bin/python -m unittest discover -s tests -p 'test_*.py' -v` (74 passed)\n- `make check`\n- `make lint`\n- `git diff --check`\n- real temporary Ollama-compatible HTTP endpoint: keyless initialization returned a response and sent model `llama3.2`\n- real headless `server.py` launch with stdin `/dev/null`: process remained alive and `/api/health` returned `status=degraded` without prompting