### PR TITLE
fix: block private destinations in webpage fetches

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,10 +2,13 @@ import tempfile
 import unittest
 import os
 import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from unittest.mock import patch
 from pathlib import Path
 
-from tools import AVAILABLE_TOOLS, allowed_tool_names, read_file, run_cmd, set_workspace_root, write_file
+import tools
+from tools import AVAILABLE_TOOLS, allowed_tool_names, read_file, read_webpage, run_cmd, set_workspace_root, write_file
 
 
 class WorkspaceToolTests(unittest.TestCase):
@@ -39,6 +42,114 @@ class WorkspaceToolTests(unittest.TestCase):
         with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}, clear=False):
             result = run_cmd(f"{sys.executable} -c 'print(\"explicit\")'")
         self.assertEqual(result, "explicit")
+
+    def test_read_webpage_blocks_private_and_reserved_destinations_before_connecting(self):
+        class PrivateHandler(BaseHTTPRequestHandler):
+            requests = 0
+
+            def do_GET(self):
+                self.__class__.requests += 1
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"loopback-only secret")
+
+            def log_message(self, *_):
+                pass
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), PrivateHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            local_url = f"http://127.0.0.1:{server.server_port}/private"
+            result = read_webpage(local_url)
+            self.assertIn("URL blocked", result)
+            self.assertEqual(PrivateHandler.requests, 0)
+        finally:
+            server.shutdown()
+            thread.join(timeout=2)
+            server.server_close()
+
+        for url in (
+            "http://10.0.0.1/",
+            "http://192.168.1.1/",
+            "http://172.16.0.1/",
+            "http://169.254.169.254/",
+            "http://224.0.0.1/",
+            "http://0.0.0.0/",
+            "http://[::1]/",
+            "http://[fe80::1]/",
+            "http://[::ffff:127.0.0.1]/",
+        ):
+            with self.subTest(url=url):
+                self.assertIn("URL blocked", read_webpage(url))
+
+    def test_hostname_resolution_to_private_address_is_blocked(self):
+        with patch("tools.socket.getaddrinfo", return_value=[(
+            tools.socket.AF_INET, tools.socket.SOCK_STREAM, tools.socket.IPPROTO_TCP,
+            "", ("10.20.30.40", 80),
+        )]):
+            result = read_webpage("http://service.example/private")
+        self.assertIn("URL blocked", result)
+        self.assertIn("10.20.30.40", result)
+
+    def test_redirect_is_revalidated_and_response_size_is_bounded(self):
+        class RedirectHandler(BaseHTTPRequestHandler):
+            requests = []
+            oversized = False
+
+            def do_GET(self):
+                self.__class__.requests.append(self.path)
+                if self.path == "/redirect":
+                    location = f"http://127.0.0.1:{self.server.server_port}/private"
+                    self.send_response(302)
+                    self.send_header("Location", location)
+                    self.end_headers()
+                    return
+                body = b"x" * (tools._MAX_WEBPAGE_BYTES + 1) if self.oversized else b"safe body"
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                try:
+                    self.wfile.write(body)
+                except (BrokenPipeError, ConnectionResetError):
+                    pass
+
+            def log_message(self, *_):
+                pass
+
+        httpd = ThreadingHTTPServer(("127.0.0.1", 0), RedirectHandler)
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        real_resolve = tools._resolve_web_destination
+        real_connect = tools.socket.create_connection
+
+        def resolve(url):
+            parsed = tools.urlsplit(url)
+            if parsed.hostname == "public.example":
+                return parsed, "public.example", parsed.port or 80, "192.0.2.10"
+            return real_resolve(url)
+
+        def connect(address, timeout=None, source_address=None):
+            if address[0] == "192.0.2.10":
+                return real_connect(("127.0.0.1", httpd.server_port), timeout, source_address)
+            return real_connect(address, timeout, source_address)
+
+        try:
+            with patch.object(tools, "_resolve_web_destination", side_effect=resolve):
+                with patch.object(tools.socket, "create_connection", side_effect=connect):
+                    result = read_webpage(f"http://public.example:{httpd.server_port}/redirect")
+            self.assertIn("URL blocked", result)
+            self.assertEqual(RedirectHandler.requests, ["/redirect"])
+
+            RedirectHandler.oversized = True
+            with patch.object(tools, "_resolve_web_destination", side_effect=resolve):
+                with patch.object(tools.socket, "create_connection", side_effect=connect):
+                    result = read_webpage(f"http://public.example:{httpd.server_port}/large")
+            self.assertIn("exceeds", result)
+        finally:
+            httpd.shutdown()
+            thread.join(timeout=2)
+            httpd.server_close()
 
 
 if __name__ == "__main__":

--- a/tools.py
+++ b/tools.py
@@ -9,8 +9,13 @@ import glob
 import tempfile
 import shutil
 import sys
+import http.client
+import ipaddress
+import socket
+import ssl
 from pathlib import Path
 from typing import Any
+from urllib.parse import urljoin, urlsplit
 
 import requests
 from browser_manager import BrowserManager
@@ -714,6 +719,151 @@ def analyze_remote_repo(args: str) -> str:
         return f"Error analyzing repository: {e}"
 
 
+_MAX_WEBPAGE_BYTES = 1_000_000
+_MAX_WEBPAGE_REDIRECTS = 5
+_CLOUD_METADATA_NETWORKS = tuple(
+    ipaddress.ip_network(network)
+    for network in (
+        "169.254.169.254/32",  # AWS/GCP/Azure and compatible metadata APIs
+        "169.254.170.2/32",    # ECS task metadata
+        "100.100.100.200/32",  # Alibaba Cloud metadata
+        "fd00:ec2::254/128",   # AWS IPv6 metadata
+    )
+)
+
+
+def _is_blocked_web_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return whether an address must never be reached by the web tool."""
+    candidates = [address]
+    if address.version == 6 and address.ipv4_mapped is not None:
+        candidates.append(address.ipv4_mapped)
+    for candidate in candidates:
+        if (
+            candidate.is_loopback
+            or candidate.is_private
+            or candidate.is_link_local
+            or candidate.is_multicast
+            or candidate.is_unspecified
+            or candidate.is_reserved
+            or any(candidate in network for network in _CLOUD_METADATA_NETWORKS)
+        ):
+            return True
+    return False
+
+
+def _resolve_web_destination(url: str) -> tuple[Any, str, int, str]:
+    """Parse a URL and return its parsed form, canonical host, port, and pinned IP."""
+    parsed = urlsplit(url)
+    scheme = parsed.scheme.lower()
+    if scheme not in {"http", "https"}:
+        raise ValueError("only http and https URLs are supported")
+    if not parsed.hostname:
+        raise ValueError("URL must include a hostname")
+    if parsed.username or parsed.password:
+        raise ValueError("credentials in URLs are not allowed")
+    if any(char.isspace() or ord(char) < 32 for char in parsed.hostname):
+        raise ValueError("hostname contains invalid characters")
+    try:
+        port = parsed.port or (443 if scheme == "https" else 80)
+    except ValueError as exc:
+        raise ValueError("URL contains an invalid port") from exc
+
+    try:
+        hostname = parsed.hostname.encode("idna").decode("ascii").lower().rstrip(".")
+    except UnicodeError as exc:
+        raise ValueError("hostname is not valid IDNA") from exc
+    if not hostname:
+        raise ValueError("URL must include a hostname")
+
+    try:
+        direct_address = ipaddress.ip_address(hostname)
+        addresses = [direct_address]
+    except ValueError:
+        try:
+            infos = socket.getaddrinfo(
+                hostname, port, family=socket.AF_UNSPEC,
+                type=socket.SOCK_STREAM, proto=socket.IPPROTO_TCP,
+            )
+        except OSError as exc:
+            raise ValueError(f"could not resolve hostname: {exc}") from exc
+        addresses = []
+        for _, _, _, _, sockaddr in infos:
+            try:
+                address = ipaddress.ip_address(sockaddr[0])
+            except ValueError:
+                continue
+            if address not in addresses:
+                addresses.append(address)
+    if not addresses:
+        raise ValueError("hostname did not resolve to an IP address")
+    blocked = next((address for address in addresses if _is_blocked_web_address(address)), None)
+    if blocked is not None:
+        raise ValueError(f"destination resolves to a blocked address: {blocked}")
+    # Validate every answer, then pin one answer for the connection.  The
+    # request never resolves the hostname again, preventing DNS rebinding.
+    return parsed, hostname, port, str(addresses[0])
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """HTTPS connection to a fixed IP while retaining hostname TLS validation."""
+
+    def __init__(self, address: str, port: int, hostname: str, timeout: float) -> None:
+        self._requested_hostname = hostname
+        super().__init__(address, port, timeout=timeout, context=ssl.create_default_context())
+
+    def connect(self) -> None:
+        sock = socket.create_connection((self.host, self.port), self.timeout, self.source_address)
+        self.sock = self._context.wrap_socket(sock, server_hostname=self._requested_hostname)
+
+
+def _read_pinned_web_response(parsed: Any, hostname: str, port: int, address: str) -> tuple[int, str, Any]:
+    """Perform one GET against the already-validated destination."""
+    if parsed.scheme.lower() == "https":
+        connection: http.client.HTTPConnection = _PinnedHTTPSConnection(address, port, hostname, 10)
+    else:
+        connection = http.client.HTTPConnection(address, port, timeout=10)
+    host_header = f"[{hostname}]" if ":" in hostname else hostname
+    default_port = 443 if parsed.scheme.lower() == "https" else 80
+    if port != default_port:
+        host_header = f"{host_header}:{port}"
+    path = parsed.path or "/"
+    if parsed.query:
+        path += f"?{parsed.query}"
+    try:
+        connection.request("GET", path, headers={
+            "Host": host_header,
+            "User-Agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/133.0.6943.126 Safari/537.36"
+            ),
+            "Accept-Encoding": "identity",
+            "Connection": "close",
+        })
+        response = connection.getresponse()
+        content_length = response.getheader("Content-Length")
+        if content_length:
+            try:
+                if int(content_length) > _MAX_WEBPAGE_BYTES:
+                    response.close()
+                    raise ValueError(f"response exceeds {_MAX_WEBPAGE_BYTES} bytes")
+            except ValueError as exc:
+                if "response exceeds" in str(exc):
+                    raise
+        body = bytearray()
+        while len(body) <= _MAX_WEBPAGE_BYTES:
+            chunk = response.read(min(64 * 1024, _MAX_WEBPAGE_BYTES + 1 - len(body)))
+            if not chunk:
+                break
+            body.extend(chunk)
+        if len(body) > _MAX_WEBPAGE_BYTES:
+            raise ValueError(f"response exceeds {_MAX_WEBPAGE_BYTES} bytes")
+        charset = response.headers.get_content_charset() or "utf-8"
+        return response.status, response.getheader("Location", ""), body.decode(charset, errors="replace")
+    finally:
+        connection.close()
+
+
 def read_webpage(args: str) -> str:
     """
     Fetch the content of a web page and return its plain‑text body.
@@ -721,26 +871,35 @@ def read_webpage(args: str) -> str:
     """
     import html
     import re
-    import requests
-    url = args.strip()
-    if not url.startswith("http"):
+    url = str(args or "").strip()
+    if not url:
         return "Error: read_webpage requires a valid URL."
     try:
-        headers = {"User-Agent": (
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/133.0.6943.126 Safari/537.36"
-        )}
-        resp = requests.get(url, headers=headers, timeout=10)
-        resp.raise_for_status()
-        text = re.sub(r"<[^>]*>", "", resp.text)
-        text = html.unescape(text)
-        text = re.sub(r"\s+", " ", text).strip()
-        if len(text) > 5000:
-            text = text[:5000] + "\n[...truncated...]"
-        return text
-    except requests.RequestException as e:
-        return f"Error fetching webpage: {e}"
+        current_url = url
+        for redirect_count in range(_MAX_WEBPAGE_REDIRECTS + 1):
+            parsed, hostname, port, address = _resolve_web_destination(current_url)
+            status, location, body = _read_pinned_web_response(parsed, hostname, port, address)
+            if status in {301, 302, 303, 307, 308}:
+                if not location:
+                    return f"Error fetching webpage: HTTP {status} redirect has no Location header"
+                if redirect_count >= _MAX_WEBPAGE_REDIRECTS:
+                    return f"Error fetching webpage: too many redirects (maximum {_MAX_WEBPAGE_REDIRECTS})"
+                current_url = urljoin(current_url, location)
+                continue
+            if status < 200 or status >= 400:
+                return f"Error fetching webpage: HTTP {status}"
+            text = re.sub(r"<[^>]*>", "", body)
+            text = html.unescape(text)
+            text = re.sub(r"\s+", " ", text).strip()
+            if len(text) > 5000:
+                text = text[:5000] + "\n[...truncated...]"
+            return text
+        return f"Error fetching webpage: too many redirects (maximum {_MAX_WEBPAGE_REDIRECTS})"
+    except (OSError, http.client.HTTPException, ValueError) as e:
+        message = str(e)
+        if "blocked address" in message or "only http" in message or "credentials in URLs" in message:
+            return f"Error: URL blocked: {message}"
+        return f"Error fetching webpage: {message}"
 
 
 def list_tree(args: str) -> str:


### PR DESCRIPTION
Fixes #9

Harden `read_webpage` with strict HTTP(S) parsing, DNS resolution and address screening, IPv4-mapped IPv6 handling, cloud metadata blocking, fixed-IP connections, manual redirect validation, and a 1 MB response limit. Private-network fetching remains disabled.

Validation:
- `./venv/bin/python -m unittest discover -s tests -p 'test_*.py' -v` (77 passed)\n- `make check`\n- `make lint`\n- `git diff --check`\n- real local HTTP server tests: loopback request blocked before handler, private DNS answer blocked, redirect to loopback revalidated before second request, oversized response rejected