### PR TITLE
fix: wire plugin lifecycle hooks across surfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ clean:
 
 # Syntax check
 lint:
-	$(VENV_PYTHON) -m compileall -q main.py server.py tools.py memory.py event_store.py task_engine.py learning_engine.py learning_benchmark.py migration.py scheduler.py skill_registry.py browser_manager.py instruction_loader.py subagents.py capability_tokens.py tool_registry.py dynamic_tools.py
+	$(VENV_PYTHON) -m compileall -q main.py server.py tools.py memory.py event_store.py task_engine.py learning_engine.py learning_benchmark.py migration.py scheduler.py skill_registry.py browser_manager.py instruction_loader.py subagents.py capability_tokens.py tool_registry.py dynamic_tools.py plugin_runtime.py
 	@echo "Python syntax OK."
 	@echo "All files pass syntax check."
 
@@ -56,7 +56,7 @@ test:
 # Quick verification
 check:
 	@echo "Checking Python syntax..."
-	@$(VENV_PYTHON) -m py_compile main.py server.py tools.py memory.py event_store.py task_engine.py learning_engine.py learning_benchmark.py migration.py scheduler.py skill_registry.py browser_manager.py instruction_loader.py subagents.py capability_tokens.py tool_registry.py dynamic_tools.py
+	@$(VENV_PYTHON) -m py_compile main.py server.py tools.py memory.py event_store.py task_engine.py learning_engine.py learning_benchmark.py migration.py scheduler.py skill_registry.py browser_manager.py instruction_loader.py subagents.py capability_tokens.py tool_registry.py dynamic_tools.py plugin_runtime.py
 	@echo "  Python modules: OK"
 	@echo "Checking git tools..."
 	@$(VENV_PYTHON) -c "from tools import AVAILABLE_TOOLS; git = [k for k in AVAILABLE_TOOLS if k.startswith('git_')]; print(f'  {len(git)} git tools, {len(AVAILABLE_TOOLS)} total tools')"

--- a/README.md
+++ b/README.md
@@ -551,6 +551,23 @@ def register():
 
 Available hooks: `on_startup`, `on_turn_start`, `on_turn_end`, `on_tool_execute`.
 
+The shared runtime loads `plugins/*.py` once per execution surface (`cli` and
+`web`) in deterministic filename order. Hook failures are isolated, recorded
+as `plugin.hook_failed` events, and never fail the user turn. Hook arguments
+are keyword arguments and are bounded/redacted before a plugin sees them:
+
+| Hook | Required kwargs | Additional context |
+|------|-----------------|--------------------|
+| `on_startup` | — | `agent`, `surface`, `user_id`, `workspace_id` |
+| `on_turn_start` | `user_input` | `surface`, `user_id`, `workspace_id`, `session_id`, `profile` |
+| `on_turn_end` | `reply`, `success` | `error` plus the turn context |
+| `on_tool_execute` | `action`, `args`, `result`, `success` | `error`, `surface`, and scope context |
+
+`on_tool_execute` fires once for every attempted action, including unknown,
+unauthorized, malformed, and approval-denied actions. `turn_logger.py` writes
+to `kyrozen_turns.log`; set `KYROZEN_TURN_LOG` to choose another path for a
+service or test.
+
 See `plugins/turn_logger.py` for a working example.
 
 ---

--- a/main.py
+++ b/main.py
@@ -102,6 +102,7 @@ from instruction_loader import format_instructions
 from subagents import AgentProfile, SubAgentManager
 from capability_tokens import issue_capability_token
 from dynamic_tools import SAFE_BUILTINS, validate_tool_source
+from plugin_runtime import get_plugin_runtime
 from tools import (AVAILABLE_TOOLS, set_workspace_root as _set_tools_workspace_root,
                    resolve_capabilities, tool_capability)
 from providers import (
@@ -1875,6 +1876,23 @@ _last_learning_run: dict[str, Any] | None = None
 _learning_notices: list[str] = []
 
 
+def _record_plugin_event(event_type: str, payload: dict[str, Any]) -> None:
+    """Persist plugin runtime diagnostics without allowing them to break work."""
+    try:
+        memory_bank.store.append_event(
+            event_type, payload, user_id=memory_bank.user_id,
+            workspace_id=memory_bank.workspace_id, session_id=memory_bank.session_id,
+        )
+    except Exception:
+        pass
+
+
+def _plugin_runtime_for_surface(surface: str | None = None):
+    return get_plugin_runtime(
+        surface or _EXECUTION_SURFACE, event_recorder=_record_plugin_event,
+    )
+
+
 def _subagent_action_arguments(action: str, args: Any) -> Any:
     """Normalise common structured action arguments without widening access."""
     if not isinstance(args, dict):
@@ -1914,12 +1932,17 @@ def _run_subagent_tool(profile: AgentProfile, action: str, args: Any, tools: set
     canonical = TOOL_ALIASES.get(str(action).strip(), str(action).strip())
     receipt_id = f"subagent_receipt_{uuid.uuid4().hex}"
     if canonical not in tools:
+        _notify_tool_execute(
+            canonical, args,
+            f"Error: tool '{canonical}' is not authorized for the '{profile.name}' profile.",
+        )
         return {
             "receipt_id": receipt_id, "action": canonical, "args": str(args)[:500],
             "result": f"Error: tool '{canonical}' is not authorized for the '{profile.name}' profile.",
             "success": False, "authorized": False,
         }
     if not isinstance(args, (str, dict)):
+        _notify_tool_execute(canonical, args, "Error: Action args must be a plain string or supported object.")
         return {
             "receipt_id": receipt_id, "action": canonical, "args": str(args)[:500],
             "result": "Error: Action args must be a plain string or supported object.",
@@ -1978,6 +2001,10 @@ def _run_subagent_llm(profile: AgentProfile, task: str, context: list[dict[str, 
             if unknown or malformed:
                 executed_steps += 1
                 rejected_action = unknown or "malformed"
+                _notify_tool_execute(
+                    str(rejected_action), "",
+                    "Error: malformed or unknown Action rejected; no tool was executed.",
+                )
                 tool_records.append({
                     "receipt_id": f"subagent_receipt_{uuid.uuid4().hex}",
                     "action": str(rejected_action), "args": "",
@@ -2561,6 +2588,22 @@ def _collect_tool_calls(text: str) -> list[dict]:
     return calls
 
 
+def _notify_tool_execute(action: str, args: Any, result: Any) -> None:
+    """Emit exactly one isolated plugin hook for every attempted tool call."""
+    result_text = str(result)
+    try:
+        _plugin_runtime_for_surface().tool_execute(
+            action=action, args=args, result=result_text,
+            success=not _is_tool_error(result_text),
+            error=None if not _is_tool_error(result_text) else result_text,
+            user_id=memory_bank.user_id, workspace_id=memory_bank.workspace_id,
+            session_id=memory_bank.session_id,
+        )
+    except Exception:
+        # A plugin is an observer and cannot change tool semantics.
+        pass
+
+
 def _run_tool(action: str, args: str) -> str:
     # Map aliases
     action = TOOL_ALIASES.get(action, action)
@@ -2593,15 +2636,21 @@ def _run_tool(action: str, args: str) -> str:
             pass
     fn = AVAILABLE_TOOLS.get(action)
     if not fn:
-        return f"Error: unknown tool '{action}'"
+        result = f"Error: unknown tool '{action}'"
+        _notify_tool_execute(action, args, result)
+        return result
     required_capability = tool_capability(action)
     if not _execution_capability_token.allows(required_capability):
-        return f"Error: tool '{action}' requires capability '{required_capability}'"
+        result = f"Error: tool '{action}' requires capability '{required_capability}'"
+        _notify_tool_execute(action, args, result)
+        return result
     if not _confirm_tool_action(action, str(args)):
-        return (
+        result = (
             f"Error: {action} requires confirmation. "
             "Approve it interactively or set KYROZEN_APPROVAL_MODE=never for an explicitly automated CLI."
         )
+        _notify_tool_execute(action, args, result)
+        return result
     start = time.time()
     try:
         result = str(fn(args))
@@ -2611,6 +2660,7 @@ def _run_tool(action: str, args: str) -> str:
         result = f"Error: {e}"
     elapsed = time.time() - start
     _track_tool_performance(action, result, elapsed)
+    _notify_tool_execute(action, args, result)
     return result
 
 
@@ -3115,8 +3165,8 @@ def _classify_complexity(user_input: str) -> str:
     return "medium"
 
 
-def _chat_turn(user_input: str, clear_tasks: bool = False, profile: str | None = None,
-               memory_context: dict[str, Any] | None = None) -> str:
+def _chat_turn_impl(user_input: str, clear_tasks: bool = False, profile: str | None = None,
+                    memory_context: dict[str, Any] | None = None) -> str:
     """One user turn: build context, get LLM reply, execute tool calls
     with automatic retries and failure memory."""
 
@@ -3189,6 +3239,9 @@ def _chat_turn(user_input: str, clear_tasks: bool = False, profile: str | None =
         if not unknown_action:
             break
         _unknown_retries += 1
+        _notify_tool_execute(
+            unknown_action, "", f"Error: unknown tool '{unknown_action}'",
+        )
         msg = (
             f"System: Action '{unknown_action}' is not recognized. "
             "You must use one of the following actions: "
@@ -3315,6 +3368,7 @@ def _chat_turn(user_input: str, clear_tasks: bool = False, profile: str | None =
                 "Example: `\"args\": \"python3 process_logs.py\"`\n"
                 "Do NOT use `\"args\": {\"cmd\": ...}`.\n"
             )
+            _notify_tool_execute(action, args, result)
         else:
             if not isinstance(args, str):
                 args = str(args)
@@ -3581,6 +3635,7 @@ def _chat_turn(user_input: str, clear_tasks: bool = False, profile: str | None =
                     "Example: `\"args\": \"python3 process_logs.py\"`\n"
                     "Do NOT use `\"args\": {\"cmd\": ...}`.\n"
                 )
+                _notify_tool_execute(action, args, result2)
             else:
                 if not isinstance(args, str):
                     args = str(args)
@@ -3695,6 +3750,30 @@ def _chat_turn(user_input: str, clear_tasks: bool = False, profile: str | None =
         learning_run, learning_receipts, user_input, final_answer, tool_records,
         turn_prompt_total + turn_completion_total, turn_start,
     )
+
+
+def _chat_turn(user_input: str, clear_tasks: bool = False, profile: str | None = None,
+               memory_context: dict[str, Any] | None = None) -> str:
+    """Run one chat turn with failure-isolated plugin lifecycle hooks."""
+    runtime = _plugin_runtime_for_surface()
+    context = {
+        "user_id": memory_bank.user_id,
+        "workspace_id": memory_bank.workspace_id,
+        "session_id": memory_bank.session_id,
+        "profile": profile or _agent_profile_mode,
+    }
+    runtime.turn_start(user_input=user_input, **context)
+    try:
+        reply = _chat_turn_impl(
+            user_input, clear_tasks=clear_tasks, profile=profile,
+            memory_context=memory_context,
+        )
+    except Exception as exc:
+        runtime.turn_end(reply="", success=False,
+                         error=f"{type(exc).__name__}: {exc}", **context)
+        raise
+    runtime.turn_end(reply=reply, success=True, **context)
+    return reply
 
 
 def _split_reply(text: str) -> tuple[str, str]:
@@ -3965,6 +4044,7 @@ def main() -> None:
         sys.exit(1)
     # Set workspace root for sandbox
     _set_workspace_root(os.getcwd())
+    _plugin_runtime_for_surface().load_once()
     task_results = _run_recovered_tasks()
     for item in task_results:
         console.print(f"[{_SUCCESS}]Durable task {item['task']['id']}: {item['status']}[/{_SUCCESS}]")

--- a/plugin_runtime.py
+++ b/plugin_runtime.py
@@ -1,0 +1,139 @@
+"""Shared, failure-isolated plugin lifecycle runtime."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import threading
+from pathlib import Path
+from typing import Any, Callable
+
+
+_RUNTIMES: dict[str, "PluginRuntime"] = {}
+_RUNTIMES_LOCK = threading.RLock()
+
+_SECRET_PATTERNS = (
+    re.compile(r"(?i)((?:api[_-]?key|password|secret|token)\s*[:=])\s*\S+"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]+"),
+)
+
+
+def _redact(value: Any, limit: int = 500) -> str:
+    text = str(value or "")
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub(lambda match: (match.group(1) + "<redacted>")
+                           if match.lastindex else "<redacted>", text)
+    return text.replace("\n", " ")[:limit]
+
+
+class PluginRuntime:
+    """Load plugins once for one execution surface and isolate every hook."""
+
+    def __init__(self, surface: str, *, plugins_dir: Path | None = None,
+                 event_recorder: Callable[[str, dict[str, Any]], None] | None = None):
+        self.surface = str(surface or "unknown")
+        self.plugins_dir = (plugins_dir or Path(__file__).parent / "plugins").resolve()
+        self.event_recorder = event_recorder
+        self._loaded = False
+        self._plugins: list[tuple[str, Any]] = []
+        self._lock = threading.RLock()
+
+    @property
+    def loaded(self) -> bool:
+        return self._loaded
+
+    @property
+    def plugin_names(self) -> tuple[str, ...]:
+        return tuple(name for name, _plugin in self._plugins)
+
+    def _record(self, event_type: str, **payload: Any) -> None:
+        if not self.event_recorder:
+            return
+        safe_payload = {key: _redact(value, 300) if isinstance(value, str) else value
+                        for key, value in payload.items()}
+        try:
+            self.event_recorder(event_type, safe_payload)
+        except Exception:
+            pass
+
+    def load_once(self) -> tuple[str, ...]:
+        with self._lock:
+            if self._loaded:
+                return self.plugin_names
+            # Set the flag before importing anything: a broken plugin must not
+            # cause another request to retry imports or duplicate registrations.
+            self._loaded = True
+            if not self.plugins_dir.is_dir():
+                self._record("plugin.loaded", plugin="<none>", status="no plugin directory")
+                return self.plugin_names
+            for path in sorted(self.plugins_dir.glob("*.py")):
+                if path.name.startswith("_"):
+                    continue
+                module_name = f"openkyrozen_plugin_{self.surface}_{path.stem}"
+                try:
+                    spec = importlib.util.spec_from_file_location(module_name, path)
+                    if spec is None or spec.loader is None:
+                        raise ImportError("could not create module spec")
+                    module = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(module)
+                    register = getattr(module, "register", None)
+                    if not callable(register):
+                        self._record("plugin.load_failed", plugin=path.stem,
+                                     error="register() is missing")
+                        continue
+                    plugin = register()
+                    if plugin is None:
+                        self._record("plugin.load_failed", plugin=path.stem,
+                                     error="register() returned no plugin")
+                        continue
+                    self._plugins.append((path.stem, plugin))
+                    self._record("plugin.loaded", plugin=path.stem, status="loaded")
+                except Exception as exc:
+                    self._record("plugin.load_failed", plugin=path.stem,
+                                 error=f"{type(exc).__name__}: {exc}")
+            return self.plugin_names
+
+    def trigger(self, hook_name: str, **kwargs: Any) -> None:
+        self.load_once()
+        for plugin_name, plugin in tuple(self._plugins):
+            hook = getattr(plugin, hook_name, None)
+            if not callable(hook):
+                continue
+            try:
+                hook(**kwargs)
+            except Exception as exc:
+                self._record(
+                    "plugin.hook_failed", plugin=plugin_name, hook=hook_name,
+                    error=f"{type(exc).__name__}: {exc}",
+                )
+
+    def turn_start(self, *, user_input: str, **context: Any) -> None:
+        self.trigger("on_turn_start", user_input=_redact(user_input, 1000),
+                     surface=self.surface, **context)
+
+    def turn_end(self, *, reply: str, success: bool, error: str | None = None,
+                 **context: Any) -> None:
+        self.trigger("on_turn_end", reply=_redact(reply, 1000), success=bool(success),
+                     error=_redact(error, 300) if error else None,
+                     surface=self.surface, **context)
+
+    def tool_execute(self, *, action: str, args: Any, result: Any, success: bool,
+                     error: str | None = None, **context: Any) -> None:
+        self.trigger(
+            "on_tool_execute", action=_redact(action, 100), args=_redact(args, 500),
+            result=_redact(result, 1000), success=bool(success),
+            error=_redact(error, 300) if error else None,
+            surface=self.surface, **context,
+        )
+
+
+def get_plugin_runtime(surface: str, *, plugins_dir: Path | None = None,
+                       event_recorder: Callable[[str, dict[str, Any]], None] | None = None) -> PluginRuntime:
+    """Return the one runtime instance for a surface in this process."""
+    key = str(surface or "unknown")
+    with _RUNTIMES_LOCK:
+        runtime = _RUNTIMES.get(key)
+        if runtime is None:
+            runtime = PluginRuntime(key, plugins_dir=plugins_dir, event_recorder=event_recorder)
+            _RUNTIMES[key] = runtime
+        return runtime

--- a/plugins/turn_logger.py
+++ b/plugins/turn_logger.py
@@ -4,13 +4,14 @@ Copy this to create your own plugins.
 """
 
 import time
+import os
 from pathlib import Path
 
 class TurnLogger:
     """Logs every conversation turn with timestamp."""
 
     def __init__(self):
-        self._log_path = Path("kyrozen_turns.log")
+        self._log_path = Path(os.environ.get("KYROZEN_TURN_LOG", "kyrozen_turns.log"))
 
     def on_turn_start(self, user_input: str, **kwargs):
         ts = time.strftime("%Y-%m-%d %H:%M:%S")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ Repository = "https://github.com/EvanProgramming/OpenKyrozen"
 Issues = "https://github.com/EvanProgramming/OpenKyrozen/issues"
 
 [tool.setuptools]
-py-modules = ["main", "memory", "providers", "server", "tools", "event_store", "learning_engine", "learning_benchmark", "migration", "task_engine", "scheduler", "skill_registry", "browser_manager", "instruction_loader", "subagents", "capability_tokens", "tool_registry", "dynamic_tools"]
+py-modules = ["main", "memory", "providers", "server", "tools", "event_store", "learning_engine", "learning_benchmark", "migration", "task_engine", "scheduler", "skill_registry", "browser_manager", "instruction_loader", "subagents", "capability_tokens", "tool_registry", "dynamic_tools", "plugin_runtime"]
 include-package-data = true
 
 [tool.setuptools.packages.find]

--- a/server.py
+++ b/server.py
@@ -1156,11 +1156,16 @@ async def mcp_endpoint(request: Request):
         tool_name = params.get("name", "")
         tool_args = params.get("arguments", "")
         if not isinstance(tool_name, str) or not tool_name:
+            _agent._notify_tool_execute(str(tool_name), tool_args, "Error: tool name is required")
             return _mcp_error(request_id, -32602, "Invalid params: tool name is required")
         fn = _agent.AVAILABLE_TOOLS.get(tool_name)
         if fn is None:
+            _agent._notify_tool_execute(tool_name, tool_args, f"Error: Tool '{tool_name}' not found")
             return _mcp_error(request_id, -32601, f"Tool '{tool_name}' not found")
         if tool_name not in _allowed_server_tools("mcp"):
+            _agent._notify_tool_execute(
+                tool_name, tool_args, f"Error: Tool '{tool_name}' is not authorized",
+            )
             return _mcp_error(request_id, -32001, (
                 f"Tool requires '{tool_capability(tool_name)}' capability; "
                 "set KYROZEN_MCP_CAPABILITIES or use the full profile to enable it"
@@ -1168,6 +1173,7 @@ async def mcp_endpoint(request: Request):
         try:
             string_args = _mcp_string_arguments(tool_name, tool_args)
         except (TypeError, ValueError) as e:
+            _agent._notify_tool_execute(tool_name, tool_args, f"Error: invalid params: {e}")
             return _mcp_error(request_id, -32602, f"Invalid params: {e}")
         try:
             previous_token = _agent._execution_capability_token
@@ -1338,38 +1344,14 @@ async def asyncio_sleep(seconds: float):
 # Plugin system
 # ---------------------------------------------------------------------------
 
-_PLUGINS: list[Any] = []
-
 def _load_plugins():
-    """Load plugins from the plugins/ directory."""
-    global _PLUGINS
-    plugins_dir = Path(__file__).parent / "plugins"
-    if not plugins_dir.is_dir():
-        plugins_dir.mkdir(exist_ok=True)
-        (plugins_dir / "__init__.py").write_text("# OpenKyrozen plugins\n")
-        return
-    for py_file in sorted(plugins_dir.glob("*.py")):
-        if py_file.name.startswith("_"):
-            continue
-        try:
-            spec = __import__(f"plugins.{py_file.stem}", fromlist=["register"])
-            if hasattr(spec, "register"):
-                plugin = spec.register()
-                _PLUGINS.append(plugin)
-                print(f"[Plugin] Loaded: {py_file.stem}")
-        except Exception as e:
-            print(f"[Plugin] Failed to load {py_file.stem}: {e}")
+    """Load the shared Web plugin runtime exactly once."""
+    return _agent._plugin_runtime_for_surface("web").load_once()
 
 
-# Hook triggers
 def _trigger_hook(hook_name: str, **kwargs):
-    for plugin in _PLUGINS:
-        fn = getattr(plugin, hook_name, None)
-        if fn:
-            try:
-                fn(**kwargs)
-            except Exception:
-                pass
+    """Compatibility wrapper for startup hooks through the shared runtime."""
+    return _agent._plugin_runtime_for_surface("web").trigger(hook_name, **kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -1388,7 +1370,10 @@ async def startup():
         print(f"[Server] Provider: {_agent._provider_config.provider}")
     _agent._load_project_files_into_memory()
     _load_plugins()
-    _trigger_hook("on_startup", agent=_agent)
+    _trigger_hook(
+        "on_startup", agent=_agent, surface="web", user_id=_SERVER_ACTOR_ID,
+        workspace_id=_agent.memory_bank.workspace_id,
+    )
     recovered = _task_worker.recover()
     if recovered:
         _audit("TASK_RECOVERY", f"recovered={len(recovered)} pending_or_resumable tasks")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,146 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import main
+import server
+from plugin_runtime import PluginRuntime
+
+
+class PluginLifecycleTests(unittest.TestCase):
+    def test_runtime_loads_once_and_isolates_each_hook_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            load_count = root / "load-count.txt"
+            hook_log = root / "hooks.log"
+            bad_plugin = root / "00_bad.py"
+            good_plugin = root / "01_good.py"
+            bad_plugin.write_text(
+                "class Bad:\n"
+                "    def on_turn_start(self, **kwargs): raise RuntimeError('start')\n"
+                "    def on_tool_execute(self, **kwargs): raise RuntimeError('tool')\n"
+                "    def on_turn_end(self, **kwargs): raise RuntimeError('end')\n"
+                "def register(): return Bad()\n",
+                encoding="utf-8",
+            )
+            good_plugin.write_text(
+                f"from pathlib import Path\n"
+                f"LOG = Path({str(hook_log)!r})\n"
+                f"COUNT = Path({str(load_count)!r})\n"
+                "def append(value):\n"
+                "    with LOG.open('a', encoding='utf-8') as handle: handle.write(value + '\\n')\n"
+                "class Good:\n"
+                "    def on_turn_start(self, user_input, **kwargs): append('start:' + user_input)\n"
+                "    def on_tool_execute(self, action, args, result, success, **kwargs): append(f'tool:{action}:{success}:{result}')\n"
+                "    def on_turn_end(self, reply, success, **kwargs): append('end:' + reply + ':' + str(success))\n"
+                "def register():\n"
+                "    COUNT.write_text(str(int(COUNT.read_text()) + 1) if COUNT.exists() else '1', encoding='utf-8')\n"
+                "    return Good()\n",
+                encoding="utf-8",
+            )
+            events = []
+            runtime = PluginRuntime("isolated", plugins_dir=root,
+                                    event_recorder=lambda event, payload: events.append((event, payload)))
+            runtime.load_once()
+            runtime.load_once()
+            runtime.turn_start(user_input="hello", user_id="local")
+            runtime.tool_execute(action="read_file", args="x", result="ok", success=True)
+            runtime.turn_end(reply="finished", success=True, user_id="local")
+
+            self.assertEqual(load_count.read_text(encoding="utf-8"), "1")
+            lines = hook_log.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(lines, ["start:hello", "tool:read_file:True:ok", "end:finished:True"])
+            failures = [payload for event, payload in events if event == "plugin.hook_failed"]
+            self.assertEqual(len(failures), 3)
+            self.assertEqual(set(runtime.plugin_names), {"00_bad", "01_good"})
+
+    def test_bundled_turn_logger_produces_a_real_turn_log(self):
+        with tempfile.TemporaryDirectory() as directory:
+            log_path = Path(directory) / "kyrozen_turns.log"
+            runtime = PluginRuntime(
+                "bundled-test", plugins_dir=Path(__file__).parents[1] / "plugins",
+            )
+            with patch.dict(os.environ, {"KYROZEN_TURN_LOG": str(log_path)}):
+                runtime.turn_start(user_input="hello")
+                runtime.tool_execute(action="read_file", args="README.md", result="ok", success=True)
+                runtime.turn_end(reply="done", success=True)
+            log = log_path.read_text(encoding="utf-8")
+            self.assertIn("USER: hello", log)
+            self.assertIn("TOOL: read_file(README.md) -> ok", log)
+            self.assertIn("AGENT: done", log)
+
+    def test_chat_wrapper_emits_start_and_end_for_success_and_failure(self):
+        class SpyRuntime:
+            def __init__(self):
+                self.calls = []
+
+            def turn_start(self, **kwargs):
+                self.calls.append(("start", kwargs))
+
+            def turn_end(self, **kwargs):
+                self.calls.append(("end", kwargs))
+
+        runtime = SpyRuntime()
+        with patch.object(main, "_plugin_runtime_for_surface", return_value=runtime), \
+             patch.object(main, "_chat_turn_impl", return_value="success"):
+            self.assertEqual(main._chat_turn("hello"), "success")
+        self.assertEqual([call[0] for call in runtime.calls], ["start", "end"])
+        self.assertTrue(runtime.calls[-1][1]["success"])
+
+        runtime.calls.clear()
+        with patch.object(main, "_plugin_runtime_for_surface", return_value=runtime), \
+             patch.object(main, "_chat_turn_impl", side_effect=RuntimeError("boom")):
+            with self.assertRaisesRegex(RuntimeError, "boom"):
+                main._chat_turn("hello")
+        self.assertEqual([call[0] for call in runtime.calls], ["start", "end"])
+        self.assertFalse(runtime.calls[-1][1]["success"])
+
+    def test_web_and_scheduled_chat_turns_use_the_same_wrapper(self):
+        class SpyRuntime:
+            def __init__(self):
+                self.calls = []
+
+            def turn_start(self, **kwargs):
+                self.calls.append(("start", kwargs))
+
+            def turn_end(self, **kwargs):
+                self.calls.append(("end", kwargs))
+
+        runtime = SpyRuntime()
+        session_id = "plugin-lifecycle-web-test"
+        session = {"messages": [], "user_id": "local", "session_id": session_id,
+                   "profile": "auto", "created": 0}
+        with patch.object(main, "_plugin_runtime_for_surface", return_value=runtime), \
+             patch.object(main, "_chat_turn_impl", return_value="web reply"):
+            self.assertEqual(server._run_session_chat(session, "web turn"), "web reply")
+            server._run_scheduled_job({"payload": {
+                "type": "chat", "session_id": "plugin-lifecycle-scheduled-test",
+                "message": "scheduled turn",
+            }})
+        self.assertEqual([call[0] for call in runtime.calls],
+                         ["start", "end", "start", "end"])
+        self.assertEqual(runtime.calls[0][1]["user_id"], server._SERVER_ACTOR_ID)
+        server._sessions.pop(session_id, None)
+        server._sessions.pop("plugin-lifecycle-scheduled-test", None)
+
+    def test_unknown_tool_attempt_triggers_one_tool_hook(self):
+        class SpyRuntime:
+            def __init__(self):
+                self.calls = []
+
+            def tool_execute(self, **kwargs):
+                self.calls.append(kwargs)
+
+        runtime = SpyRuntime()
+        with patch.object(main, "_plugin_runtime_for_surface", return_value=runtime):
+            result = main._run_tool("does_not_exist", "secret=hidden")
+        self.assertIn("unknown tool", result)
+        self.assertEqual(len(runtime.calls), 1)
+        self.assertEqual(runtime.calls[0]["action"], "does_not_exist")
+        self.assertFalse(runtime.calls[0]["success"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- load plugins once per CLI/Web surface through a shared failure-isolated runtime
- emit turn and exactly-once per-attempt tool lifecycle hooks, including rejected actions
- document bounded/redacted hook kwargs and configurable bundled turn logging

## Validation
- `make check`
- `make lint`
- `make test` (96 tests)
- `git diff --check`
- real bundled turn logger output plus CLI, Web, scheduled, and MCP lifecycle coverage

Fixes #18