### PR TITLE
fix: emit chat completion webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,16 @@ loopback destinations are blocked unless `KYROZEN_BROWSER_ALLOW_PRIVATE=1` is se
 | `POST` | `/api/webhooks/register` | Register a webhook URL |
 | `GET` | `/api/webhooks` | List registered webhooks |
 | `POST` | `/api/webhooks/test` | Fire a test webhook |
+
+Successful `POST /api/chat` requests emit one `chat.completed` webhook after
+the reply is produced. `POST /api/chat/stream` emits the same event only after
+the SSE stream has sent `[DONE]`; failed or disconnected streams do not emit
+it. The POST body is `{"event":"chat.completed","data":{...}}`, where
+`data` contains only the bounded `actor`, `session_id`, `profile`,
+`reply_summary`, `reply_length`, and `streamed` fields. Reply summaries are
+limited to 500 characters and redact common API-key/token patterns. Webhook
+delivery errors are audited as `WEBHOOK_FAILURE` and never change the chat
+response.
 | `POST` | `/mcp` | Model Context Protocol (JSON-RPC 2.0) |
 
 API and MCP routes allow direct loopback access without a token. Any

--- a/server.py
+++ b/server.py
@@ -537,6 +537,7 @@ async def api_chat(request: Request):
         _audit("ERROR", str(e), session["user_id"])
         raise HTTPException(500, str(e))
 
+    _emit_chat_completed(session, reply, streamed=False)
     _audit("REPLY", f"len={len(reply)}", session["user_id"])
     return {"reply": reply, "session_id": session_id, "profile": session["profile"],
             "memory_receipt": session.get("last_memory_receipt"), "cost": get_cost_summary()}
@@ -576,6 +577,7 @@ async def api_chat_stream(request: Request):
             if session.get("last_memory_receipt"):
                 yield f"data: {json.dumps({'memory_receipt': session['last_memory_receipt']})}\n\n"
             yield "data: [DONE]\n\n"
+            _emit_chat_completed(session, reply, streamed=True)
             _audit("REPLY_STREAM", f"len={len(reply)}", session["user_id"])
         except Exception as e:
             yield f"data: {json.dumps({'error': str(e)})}\n\n"
@@ -1253,6 +1255,43 @@ async def api_speak(text: str = ""):
 _webhooks: list[dict] = []
 _MAX_WEBHOOKS = 32
 _ALLOWED_WEBHOOK_EVENTS = {"chat.completed", "test"}
+_WEBHOOK_SUMMARY_CHARS = 500
+
+
+def _redact_webhook_value(value: Any, limit: int = _WEBHOOK_SUMMARY_CHARS) -> str:
+    """Bound and redact values before they leave the server process."""
+    text = str(value or "")
+    patterns = (
+        (r"(?i)((?:api[_-]?key|password|secret|token)\s*[:=])\s*\S+", r"\1<redacted>"),
+        (r"\bsk-[A-Za-z0-9_-]+", "<redacted>"),
+    )
+    for pattern, replacement in patterns:
+        text = re.sub(pattern, replacement, text)
+    return text.replace("\n", " ")[:limit]
+
+
+def _chat_completed_payload(session: dict[str, Any], reply: str, *, streamed: bool) -> dict[str, Any]:
+    """Build the documented, minimal payload for a completed chat."""
+    return {
+        "actor": _redact_webhook_value(session.get("user_id", _SERVER_ACTOR_ID), 64),
+        "session_id": _redact_webhook_value(session.get("session_id", ""), 128),
+        "profile": _redact_webhook_value(session.get("profile", "auto"), 32),
+        "reply_summary": _redact_webhook_value(reply),
+        "reply_length": len(str(reply)),
+        "streamed": bool(streamed),
+    }
+
+
+def _emit_chat_completed(session: dict[str, Any], reply: str, *, streamed: bool) -> None:
+    """Emit one completion event without making webhook delivery part of chat."""
+    try:
+        _fire_webhooks("chat.completed", _chat_completed_payload(
+            session, reply, streamed=streamed,
+        ))
+    except Exception as exc:
+        # Keep a defensive boundary around custom/test senders as well as the
+        # normal requests-based sender.
+        _audit("WEBHOOK_FAILURE", f"event=chat.completed error={type(exc).__name__}: {exc}")
 
 
 def _validate_webhook_url(url: str) -> bool:
@@ -1304,14 +1343,29 @@ async def list_webhooks():
 
 
 def _fire_webhooks(event: str, data: dict):
-    """Fire webhooks for a given event."""
-    import requests as _req
-    for hook in _webhooks:
+    """Fire webhooks and audit delivery failures without raising to callers."""
+    try:
+        import requests as _req
+    except Exception as exc:
+        _audit("WEBHOOK_FAILURE", f"event={event} error={type(exc).__name__}: {exc}")
+        return {"sent": 0, "failed": 0}
+    sent = failed = 0
+    for hook in tuple(_webhooks):
         if event in hook["events"]:
             try:
-                _req.post(hook["url"], json={"event": event, "data": data}, timeout=5)
-            except Exception:
-                pass
+                response = _req.post(hook["url"], json={"event": event, "data": data}, timeout=5)
+                status_code = getattr(response, "status_code", 200)
+                if status_code >= 400:
+                    raise RuntimeError(f"HTTP {status_code}")
+                sent += 1
+            except Exception as exc:
+                failed += 1
+                _audit(
+                    "WEBHOOK_FAILURE",
+                    f"event={event} url={_redact_webhook_value(hook.get('url', ''), 256)} "
+                    f"error={type(exc).__name__}: {exc}",
+                )
+    return {"sent": sent, "failed": failed}
 
 
 @app.post("/api/webhooks/test", dependencies=[Depends(require_api_access)])

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,153 @@
+import json
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+import server
+
+
+class _WebhookReceiver:
+    def __init__(self):
+        self.bodies = []
+        self._lock = threading.Lock()
+        self.httpd = None
+        self.thread = None
+
+    def __enter__(self):
+        receiver = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):  # noqa: N802 - stdlib HTTP server contract
+                length = int(self.headers.get("content-length", "0"))
+                payload = json.loads(self.rfile.read(length).decode("utf-8"))
+                with receiver._lock:
+                    receiver.bodies.append(payload)
+                self.send_response(204)
+                self.end_headers()
+
+            def log_message(self, *_args):
+                return
+
+        self.httpd = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.thread = threading.Thread(target=self.httpd.serve_forever, daemon=True)
+        self.thread.start()
+        return self
+
+    @property
+    def url(self):
+        return f"http://127.0.0.1:{self.httpd.server_port}/hook"
+
+    def wait_for(self, count):
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline:
+            with self._lock:
+                if len(self.bodies) >= count:
+                    return
+            time.sleep(0.01)
+
+    def __exit__(self, *_args):
+        self.httpd.shutdown()
+        self.httpd.server_close()
+        self.thread.join(timeout=2)
+
+
+class WebhookEndpointTests(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(server.app)
+        self.original_webhooks = server._webhooks
+        server._webhooks = []
+
+    def tearDown(self):
+        server._webhooks = self.original_webhooks
+
+    def _use_receiver(self, receiver):
+        server._webhooks.append({
+            "url": receiver.url,
+            "events": ["chat.completed"],
+        })
+
+    def test_non_stream_chat_emits_one_bounded_redacted_completion(self):
+        with _WebhookReceiver() as receiver:
+            self._use_receiver(receiver)
+            reply = "secret=sk-live-should-not-leak " + ("usable reply " * 100)
+            with patch.object(server, "_run_session_chat", return_value=reply):
+                response = self.client.post("/api/chat", json={
+                    "message": "hello",
+                    "session_id": "webhook-non-stream",
+                    "profile": "coder",
+                })
+
+            self.assertEqual(response.status_code, 200, response.text)
+            receiver.wait_for(1)
+            self.assertEqual(len(receiver.bodies), 1)
+            event = receiver.bodies[0]
+            self.assertEqual(event["event"], "chat.completed")
+            data = event["data"]
+            self.assertEqual(data["actor"], server._SERVER_ACTOR_ID)
+            self.assertEqual(data["session_id"], "webhook-non-stream")
+            self.assertEqual(data["profile"], "coder")
+            self.assertFalse(data["streamed"])
+            self.assertEqual(data["reply_length"], len(reply))
+            self.assertLessEqual(len(data["reply_summary"]), 500)
+            self.assertNotIn("sk-live-should-not-leak", data["reply_summary"])
+
+    def test_non_stream_chat_error_emits_no_completion(self):
+        with _WebhookReceiver() as receiver:
+            self._use_receiver(receiver)
+            with patch.object(server, "_run_session_chat", side_effect=RuntimeError("provider down")):
+                response = self.client.post("/api/chat", json={
+                    "message": "hello", "session_id": "webhook-error",
+                })
+            self.assertEqual(response.status_code, 500)
+            self.assertEqual(receiver.bodies, [])
+
+    def test_stream_completion_emits_exactly_one_event_after_done(self):
+        with _WebhookReceiver() as receiver:
+            self._use_receiver(receiver)
+            with patch.object(server, "_run_session_chat", return_value="streamed reply"):
+                response = self.client.post("/api/chat/stream", json={
+                    "message": "hello", "session_id": "webhook-stream",
+                    "profile": "researcher",
+                })
+            self.assertEqual(response.status_code, 200, response.text)
+            self.assertIn("data: [DONE]", response.text)
+            receiver.wait_for(1)
+            self.assertEqual(len(receiver.bodies), 1)
+            event = receiver.bodies[0]
+            self.assertEqual(event["event"], "chat.completed")
+            self.assertTrue(event["data"]["streamed"])
+            self.assertEqual(event["data"]["reply_summary"], "streamed reply")
+
+    def test_stream_error_emits_no_completion(self):
+        with _WebhookReceiver() as receiver:
+            self._use_receiver(receiver)
+            with patch.object(server, "_run_session_chat", side_effect=RuntimeError("provider down")):
+                response = self.client.post("/api/chat/stream", json={
+                    "message": "hello", "session_id": "webhook-stream-error",
+                })
+            self.assertEqual(response.status_code, 200, response.text)
+            self.assertIn('"error": "provider down"', response.text)
+            self.assertNotIn("data: [DONE]", response.text)
+            self.assertEqual(receiver.bodies, [])
+
+    def test_webhook_failure_is_audited_without_breaking_chat(self):
+        server._webhooks.append({
+            "url": "https://example.com/hook",
+            "events": ["chat.completed"],
+        })
+        with patch("requests.post", side_effect=OSError("offline")), \
+             patch.object(server, "_audit") as audit, \
+             patch.object(server, "_run_session_chat", return_value="reply"):
+            response = self.client.post("/api/chat", json={
+                "message": "hello", "session_id": "webhook-failure",
+            })
+        self.assertEqual(response.status_code, 200, response.text)
+        self.assertTrue(any(call.args[0] == "WEBHOOK_FAILURE" for call in audit.call_args_list))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- emit one documented `chat.completed` event for successful non-streaming chats
- emit only after `[DONE]` for completed streams, with no event on chat errors
- bound and redact payloads, audit delivery failures, and keep webhook faults outside chat responses

## Validation
- `make check`
- `make lint`
- `make test` (101 tests)
- `git diff --check`
- real local HTTP receiver verified non-stream and SSE payload delivery and exactly-once behavior
- provider/error stream and failed webhook isolation verified

Fixes #17