### PR TITLE
fix: restore maintained debug entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,7 @@ Thumbs.db
 *.config.json
 .kyrozen_*
 
-# Debug and test files
-main_debug.py
+# Debug and test runtime files
 test_chat_turn.py
 _test_regression_tmp.txt
 kyrozen_audit.log

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ web:
 
 debug:
 	@command -v $(PYTHON) >/dev/null 2>&1 || { echo "Error: venv requires $(PYTHON). Run 'make install' first."; exit 1; }
-	. venv/bin/activate && python main_debug.py
+	$(VENV_PYTHON) main_debug.py
 
 init:
 	@command -v $(PYTHON) >/dev/null 2>&1 || { echo "Error: venv requires $(PYTHON). Run 'make install' first."; exit 1; }
@@ -45,7 +45,7 @@ clean:
 
 # Syntax check
 lint:
-	$(VENV_PYTHON) -m compileall -q main.py server.py tools.py memory.py event_store.py task_engine.py learning_engine.py learning_benchmark.py migration.py scheduler.py skill_registry.py browser_manager.py instruction_loader.py agent_config.py subagents.py capability_tokens.py tool_registry.py dynamic_tools.py plugin_runtime.py
+	$(VENV_PYTHON) -m compileall -q main.py main_debug.py server.py tools.py memory.py event_store.py task_engine.py learning_engine.py learning_benchmark.py migration.py scheduler.py skill_registry.py browser_manager.py instruction_loader.py agent_config.py subagents.py capability_tokens.py tool_registry.py dynamic_tools.py plugin_runtime.py
 	@echo "Python syntax OK."
 	@echo "All files pass syntax check."
 
@@ -56,7 +56,7 @@ test:
 # Quick verification
 check:
 	@echo "Checking Python syntax..."
-	@$(VENV_PYTHON) -m py_compile main.py server.py tools.py memory.py event_store.py task_engine.py learning_engine.py learning_benchmark.py migration.py scheduler.py skill_registry.py browser_manager.py instruction_loader.py agent_config.py subagents.py capability_tokens.py tool_registry.py dynamic_tools.py plugin_runtime.py
+	@$(VENV_PYTHON) -m py_compile main.py main_debug.py server.py tools.py memory.py event_store.py task_engine.py learning_engine.py learning_benchmark.py migration.py scheduler.py skill_registry.py browser_manager.py instruction_loader.py agent_config.py subagents.py capability_tokens.py tool_registry.py dynamic_tools.py plugin_runtime.py
 	@echo "  Python modules: OK"
 	@echo "Checking git tools..."
 	@$(VENV_PYTHON) -c "from tools import AVAILABLE_TOOLS; git = [k for k in AVAILABLE_TOOLS if k.startswith('git_')]; print(f'  {len(git)} git tools, {len(AVAILABLE_TOOLS)} total tools')"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 .PHONY: install run clean lint test check git-status git-diff git-log web
 
-# Use a known-stable Python version (3.14 has import deadlocks with openai)
-PYTHON := python3.12
+# Prefer the known-stable Python 3.12, but use supported Python 3.13 on clean
+# runners that do not provide 3.12.  Python 3.14 remains intentionally out of
+# scope because of the OpenAI SDK import deadlock.
+PYTHON ?= python3.12
+PYTHON := $(shell if command -v "$(PYTHON)" >/dev/null 2>&1; then printf '%s' "$(PYTHON)"; elif command -v python3.13 >/dev/null 2>&1; then printf '%s' python3.13; else printf '%s' "$(PYTHON)"; fi)
 VENV_PYTHON := $(if $(wildcard venv/bin/python),./venv/bin/python,$(PYTHON))
 
 # Detect Windows (native cmd) and redirect to .bat files

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 .PHONY: install run clean lint test check git-status git-diff git-log web
 
-# Prefer the known-stable Python 3.12, but use supported Python 3.13 on clean
-# runners that do not provide 3.12.  Python 3.14 remains intentionally out of
-# scope because of the OpenAI SDK import deadlock.
+# Prefer the known-stable Python 3.12, but use the active supported Python
+# 3.13 on clean runners that do not provide 3.12. Python 3.14 remains
+# intentionally out of scope because of the OpenAI SDK import deadlock.
 PYTHON ?= python3.12
-PYTHON := $(shell if command -v "$(PYTHON)" >/dev/null 2>&1; then printf '%s' "$(PYTHON)"; elif command -v python3.13 >/dev/null 2>&1; then printf '%s' python3.13; else printf '%s' "$(PYTHON)"; fi)
+_PYTHON_REQUEST := $(PYTHON)
+PYTHON := $(shell if [ "$(_PYTHON_REQUEST)" != "python3.12" ]; then printf '%s' "$(_PYTHON_REQUEST)"; elif command -v python >/dev/null 2>&1 && python -c 'import sys; raise SystemExit(0 if sys.version_info[:2] in ((3, 12), (3, 13)) else 1)' >/dev/null 2>&1; then command -v python; elif command -v python3.12 >/dev/null 2>&1 && python3.12 -c 'import sys; raise SystemExit(0 if sys.version_info[:2] == (3, 12) else 1)' >/dev/null 2>&1; then command -v python3.12; elif command -v python3.13 >/dev/null 2>&1 && python3.13 -c 'import sys; raise SystemExit(0 if sys.version_info[:2] == (3, 13) else 1)' >/dev/null 2>&1; then command -v python3.13; else printf '%s' "$(_PYTHON_REQUEST)"; fi)
 VENV_PYTHON := $(if $(wildcard venv/bin/python),./venv/bin/python,$(PYTHON))
 
 # Detect Windows (native cmd) and redirect to .bat files

--- a/README.md
+++ b/README.md
@@ -733,8 +733,11 @@ make check
 # Syntax lint only
 make lint
 
-# Debug mode (format-error traps)
+# Debug mode (isolated, non-interactive smoke test; never prompts for a key)
 make debug
+
+# Start the normal interactive CLI explicitly from the debug entry point
+./venv/bin/python main_debug.py --interactive
 
 # First-time API key setup
 make init

--- a/main_debug.py
+++ b/main_debug.py
@@ -1,0 +1,130 @@
+"""Maintained debug entry point for OpenKyrozen.
+
+The default command is a deterministic, non-interactive smoke test.  It uses
+an isolated temporary database and workspace, exercises provider startup,
+configuration loading, the real file tools, and the active Python interpreter,
+then exits with a useful status code.  It never asks for an API key.
+
+Use ``python main_debug.py --interactive`` when an interactive CLI session is
+wanted; that mode intentionally follows the normal credential prompt flow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import faulthandler
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run an isolated OpenKyrozen diagnostic smoke test."
+    )
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        help="start the normal interactive CLI instead of the smoke test",
+    )
+    return parser
+
+
+def _path_from_tool_output(output: str) -> Path | None:
+    candidate = output.strip().splitlines()[-1] if output.strip() else ""
+    if not candidate or candidate.startswith(("Error", "Exit code")):
+        return None
+    try:
+        return Path(candidate).expanduser().resolve()
+    except (OSError, ValueError):
+        return None
+
+
+def run_smoke() -> int:
+    """Run the real local startup and tool path without external services."""
+    # Keep this diagnostic process independent of personal credentials and
+    # runtime state.  The environment changes affect only this child process.
+    os.environ["KYROZEN_PROVIDER"] = "ollama"
+    os.environ.pop("KYROZEN_API_KEY", None)
+    for variable in ("DEEPSEEK_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY"):
+        os.environ.pop(variable, None)
+    os.environ["KYROZEN_EXECUTION_SURFACE"] = "cli"
+    os.environ["KYROZEN_DISABLE_VECTOR_INDEX"] = "1"
+
+    repository_root = Path(__file__).resolve().parent
+    with tempfile.TemporaryDirectory(prefix="openkyrozen-debug-state-") as state_dir, \
+            tempfile.TemporaryDirectory(prefix="openkyrozen-debug-workspace-") as workspace_dir:
+        os.environ["KYROZEN_DB_PATH"] = str(Path(state_dir) / "debug.sqlite3")
+
+        import main as agent
+        from agent_config import load_agent_config
+
+        workspace = Path(workspace_dir)
+        agent._set_workspace_root(str(workspace))
+        failures: list[str] = []
+
+        config = load_agent_config(repository_root)
+        if config["role"]["name"] != "assistant":
+            failures.append("packaged agent role did not load")
+        if not config["examples"]:
+            failures.append("packaged prompt examples did not load")
+
+        provider_initialized = agent._prompt_and_init_deepseek(interactive=False)
+        if not provider_initialized or agent.llm_provider is None:
+            failures.append("keyless Ollama startup did not initialise")
+
+        write_result = agent._run_tool("write_file", "debug-smoke.txt|debug-ok")
+        smoke_file = workspace / "debug-smoke.txt"
+        if not smoke_file.is_file() or smoke_file.read_text(encoding="utf-8") != "debug-ok":
+            failures.append(f"write_file had no observable effect: {write_result}")
+
+        read_result = agent._run_tool("read_file", "debug-smoke.txt")
+        if read_result != "debug-ok":
+            failures.append(f"read_file returned {read_result!r}")
+
+        interpreter_result = agent._run_tool(
+            "run_cmd", "python -c 'import sys; print(sys.executable)'"
+        )
+        actual_interpreter = _path_from_tool_output(interpreter_result)
+        expected_interpreter = Path(sys.executable).resolve()
+        if actual_interpreter != expected_interpreter:
+            failures.append(
+                f"run_cmd used {actual_interpreter}, expected {expected_interpreter}"
+            )
+
+        messages = agent._build_messages("debug smoke")
+        if not messages or "## Available Tools" not in messages[0]["content"]:
+            failures.append("the normal prompt/tool inventory did not build")
+
+        report = {
+            "python": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+            "interpreter": str(expected_interpreter),
+            "provider": agent._provider_config.provider if agent._provider_config else None,
+            "provider_initialized": bool(provider_initialized),
+            "workspace_tool_effect": smoke_file.is_file() and read_result == "debug-ok",
+            "memory_path_isolated": str(agent.memory_bank.db_path).startswith(state_dir),
+            "failures": failures,
+        }
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+        if failures:
+            print("OpenKyrozen debug smoke failed.", file=sys.stderr)
+            return 1
+        print("OpenKyrozen debug smoke passed.")
+        return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Dispatch either the safe smoke test or the explicitly interactive CLI."""
+    faulthandler.enable()
+    args = _parser().parse_args(argv)
+    if args.interactive:
+        import main as agent
+        agent.main()
+        return 0
+    return run_smoke()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_debug_entry.py
+++ b/tests/test_debug_entry.py
@@ -1,0 +1,55 @@
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class DebugEntryTests(unittest.TestCase):
+    def test_make_debug_runs_real_isolated_smoke_without_prompting(self):
+        repository = Path(__file__).parents[1]
+        with tempfile.TemporaryDirectory() as home, tempfile.TemporaryDirectory() as state:
+            env = os.environ.copy()
+            env.update({
+                "HOME": home,
+                "KYROZEN_DB_PATH": str(Path(state) / "caller.sqlite3"),
+                "KYROZEN_DISABLE_VECTOR_INDEX": "1",
+            })
+            for variable in (
+                "KYROZEN_PROVIDER", "KYROZEN_API_KEY", "DEEPSEEK_API_KEY",
+                "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY",
+            ):
+                env.pop(variable, None)
+            result = subprocess.run(
+                ["make", "debug"],
+                cwd=repository,
+                env=env,
+                input="",
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertIn("OpenKyrozen debug smoke passed.", result.stdout)
+        self.assertIn('"workspace_tool_effect": true', result.stdout)
+        self.assertIn('"memory_path_isolated": true', result.stdout)
+        self.assertNotIn("Enter your", result.stdout + result.stderr)
+
+    def test_help_is_available_without_importing_or_initialising_provider(self):
+        repository = Path(__file__).parents[1]
+        result = subprocess.run(
+            [sys.executable, "main_debug.py", "--help"],
+            cwd=repository,
+            input="",
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--interactive", result.stdout)
+        self.assertNotIn("Enter your", result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- restore a tracked `main_debug.py` entry point with an isolated, deterministic smoke test
- make `make debug` invoke the active project interpreter directly
- keep interactive credential prompting opt-in via `--interactive` and document both modes
- add subprocess coverage for real tool effects, interpreter selection, isolation, and no-prompt behavior

## Validation
- `make debug` (real 3.12.13 run: keyless Ollama startup, file tools, interpreter, isolated SQLite)
- `make check`
- `make lint`
- `make test` (118 tests)
- `git diff --check`

Fixes #26