### PR TITLE
feat: ship a runnable learning benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install run clean lint test check git-status git-diff git-log web
+.PHONY: install run clean lint test check benchmark git-status git-diff git-log web
 
 # Prefer the known-stable Python 3.12, but use the active supported Python
 # 3.13 on clean runners that do not provide 3.12. Python 3.14 remains
@@ -56,6 +56,17 @@ lint:
 # Unit tests
 test:
 	$(VENV_PYTHON) -m unittest discover -s tests -p 'test_*.py' -v
+
+benchmark:
+	@$(VENV_PYTHON) -c "import openai, requests, rich, yaml" >/dev/null 2>&1 || { echo "Error: benchmark dependencies are missing. Run 'make install' first."; exit 1; }
+	@benchmark_root=$$(mktemp -d "$${TMPDIR:-/tmp}/openkyrozen-benchmark.XXXXXX"); \
+	trap 'rm -rf "$$benchmark_root"' EXIT INT TERM; \
+	KYROZEN_BENCHMARK_ROOT="$$benchmark_root" KYROZEN_DB_PATH="$$benchmark_root/driver.sqlite3" KYROZEN_DISABLE_VECTOR_INDEX=1 \
+	$(VENV_PYTHON) main.py learning benchmark \
+		--cases benchmarks/multi_party_memory.jsonl \
+		--clean-runner "$(VENV_PYTHON) benchmarks/clean_runner.py" \
+		--evolved-runner "$(VENV_PYTHON) benchmarks/evolved_runner.py" \
+		--timeout "$${BENCHMARK_TIMEOUT:-60}"
 
 # Quick verification
 check:

--- a/README.md
+++ b/README.md
@@ -455,15 +455,43 @@ curl -X POST http://127.0.0.1:8000/api/v2/tasks \
 curl -X POST http://127.0.0.1:8000/api/v2/tasks/<task-id>/resume
 ```
 
-Run a frozen clean-versus-evolved benchmark with identical case order and runner settings:
+Run the frozen clean-versus-evolved benchmark from a fresh checkout after
+`make install`:
 
 ```bash
-python main.py learning benchmark --cases cases.jsonl \
-  --clean-runner './clean-wrapper' --evolved-runner './evolved-wrapper' \
-  --output benchmark.json
+make benchmark
 ```
 
-Each JSONL case requires `id`, `profile`, and `task`. Each wrapper reads one case from stdin and emits `verified_success`, `corrections`, `repeated_errors`, `tool_calls`, `tokens`, and `latency`. The exported `openkyrozen-learning-benchmark-v1` JSON is harness-neutral and suppresses a superiority claim unless completion is non-regressing, statistically credible, and a secondary measure improves.
+`make benchmark` uses the repository's
+`benchmarks/multi_party_memory.jsonl` fixture and the shipped
+`benchmarks/clean_runner.py` and `benchmarks/evolved_runner.py` wrappers. It
+creates a temporary benchmark root, assigns separate `clean.sqlite3` and
+`evolved.sqlite3` databases, and isolates the benchmark driver's database with
+`KYROZEN_DB_PATH`; the temporary root is removed when the command exits. The
+wrappers use a deterministic local memory policy, so no provider, model, or
+API key is required. Set `BENCHMARK_TIMEOUT=120` to change the per-case limit.
+
+For direct use, provide an isolated root explicitly:
+
+```bash
+benchmark_root="$(mktemp -d)"
+KYROZEN_BENCHMARK_ROOT="$benchmark_root" \
+  ./venv/bin/python main.py learning benchmark \
+  --cases benchmarks/multi_party_memory.jsonl \
+  --clean-runner "./venv/bin/python benchmarks/clean_runner.py" \
+  --evolved-runner "./venv/bin/python benchmarks/evolved_runner.py"
+rm -rf "$benchmark_root"
+```
+
+Each JSONL case requires `id`, `profile`, and `task`. Each wrapper reads one
+case from stdin and emits `verified_success`, `corrections`,
+`repeated_errors`, `tool_calls`, `tokens`, `latency`, `provider`, `model`, and
+`evidence_status`, plus bounded evidence counts and scope. The exported
+`openkyrozen-learning-benchmark-v1` JSON includes the protocol, runner
+metadata, provider/model, and evidence policy. Fixture-only evidence is
+reported as `fixture_verified` and therefore cannot support a product
+superiority claim; such a claim requires independently verified paired runs
+with the same provider, model, configuration, and observable product behavior.
 
 ---
 

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Runnable benchmark fixtures and local runner examples."""

--- a/benchmarks/clean_runner.py
+++ b/benchmarks/clean_runner.py
@@ -1,0 +1,7 @@
+"""Clean baseline runner for the frozen multi-party memory fixture."""
+
+from fixture_runner import run_stdin_case
+
+
+if __name__ == "__main__":
+    run_stdin_case("clean")

--- a/benchmarks/evolved_runner.py
+++ b/benchmarks/evolved_runner.py
@@ -1,0 +1,7 @@
+"""Evolved-policy runner for the frozen multi-party memory fixture."""
+
+from fixture_runner import run_stdin_case
+
+
+if __name__ == "__main__":
+    run_stdin_case("evolved")

--- a/benchmarks/fixture_runner.py
+++ b/benchmarks/fixture_runner.py
@@ -1,0 +1,176 @@
+"""Deterministic local runner for the frozen multi-party memory fixture.
+
+This runner exercises the real SQLite-backed memory boundary without an
+external provider or API key. It is deliberately a harness fixture, not a
+claim that the product is superior to another model or provider.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+if str(REPOSITORY_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPOSITORY_ROOT))
+
+os.environ.setdefault("KYROZEN_DISABLE_VECTOR_INDEX", "1")
+
+from memory import MemoryBank  # noqa: E402
+
+
+PROVIDER = "deterministic-fixture"
+MODEL = "openkyrozen-memory-policy-v1"
+WORKSPACE_ID = "multi-party-memory-fixture"
+
+
+def _database_for(mode: str) -> Path:
+    root = os.environ.get("KYROZEN_BENCHMARK_ROOT", "").strip()
+    if not root:
+        raise RuntimeError(
+            "KYROZEN_BENCHMARK_ROOT is required; run `make benchmark` "
+            "or set it to an isolated temporary directory"
+        )
+    state_root = Path(root).expanduser().resolve()
+    state_root.mkdir(parents=True, exist_ok=True)
+    return state_root / f"{mode}.sqlite3"
+
+
+def _remember(bank: MemoryBank, content: str, **metadata: Any) -> str:
+    return bank.add_log(content, kind="fact", confidence=1.0, metadata=metadata)
+
+
+def _records(bank: MemoryBank, query: str, **context: Any) -> list[dict[str, Any]]:
+    return bank.recall_records(query, n_results=20, **context)
+
+
+def _speaker_belief_isolation(bank: MemoryBank) -> tuple[bool, int, list[str]]:
+    _remember(bank, "The release date is Monday.", speaker="alice", claim_type="belief")
+    _remember(bank, "The release date is Tuesday.", speaker="bob", claim_type="belief")
+    alice = _records(bank, "release date", speaker="alice", authorized_speakers={"alice"})
+    bob = _records(bank, "release date", speaker="bob", authorized_speakers={"bob"})
+    passed = (
+        len(alice) == 1 and alice[0]["metadata"].get("speaker") == "alice"
+        and len(bob) == 1 and bob[0]["metadata"].get("speaker") == "bob"
+    )
+    return passed, 4, ["speaker-scoped recall preserved both attributed beliefs"]
+
+
+def _speaker_update(bank: MemoryBank) -> tuple[bool, int, list[str]]:
+    old_alice = _remember(bank, "Alice says the release date is Monday.", speaker="alice", claim_type="belief")
+    _remember(bank, "Bob says the release date is Tuesday.", speaker="bob", claim_type="belief")
+    bank.store.set_memory_status(old_alice, "superseded", workspace_id=bank.workspace_id, user_id=bank.user_id)
+    bank.store.append_event(
+        "memory.superseded",
+        {"memory_id": old_alice, "replacement": "Wednesday", "speaker": "alice"},
+        user_id=bank.user_id, workspace_id=bank.workspace_id, session_id=bank.session_id,
+    )
+    _remember(bank, "Alice says the release date is Wednesday.", speaker="alice", claim_type="belief")
+    alice = _records(bank, "release date", speaker="alice", authorized_speakers={"alice"})
+    bob = _records(bank, "release date", speaker="bob", authorized_speakers={"bob"})
+    alice_text = " ".join(row["content"] for row in alice)
+    bob_text = " ".join(row["content"] for row in bob)
+    passed = "Wednesday" in alice_text and "Monday" not in alice_text and bob_text.endswith("Tuesday.")
+    return passed, 7, ["Alice's old claim was superseded while Bob's claim remained active"]
+
+
+def _private_leakage(bank: MemoryBank) -> tuple[bool, int, list[str]]:
+    _remember(
+        bank, "Alice's private budget is 7000 dollars.", speaker="alice",
+        visibility="private", claim_type="private_fact",
+    )
+    bob = _records(bank, "private budget", speaker="bob", authorized_speakers={"bob"})
+    alice = _records(bank, "private budget", speaker="alice", authorized_speakers={"alice"})
+    passed = not bob and len(alice) == 1 and "7000" in alice[0]["content"]
+    return passed, 4, ["private memory was visible to its owner and hidden from Bob"]
+
+
+def _audience_language(bank: MemoryBank) -> tuple[bool, int, list[str]]:
+    _remember(
+        bank, "The release agreement uses blue-green deployment.", speaker="team",
+        visibility="group", audiences=["engineering"], claim_type="group_agreement",
+    )
+    engineering = _records(bank, "release agreement", audience="engineering")
+    sales = _records(bank, "release agreement", audience="sales")
+    passed = len(engineering) == 1 and not sales and "blue-green" in engineering[0]["content"]
+    return passed, 4, ["group agreement was visible only to the engineering audience"]
+
+
+def _term_ambiguity(bank: MemoryBank) -> tuple[bool, int, list[str]]:
+    _remember(bank, "For Alice, Orion means the public launch date.", speaker="alice", claim_type="term")
+    _remember(bank, "For Bob, Orion means the internal project codename.", speaker="bob", claim_type="term")
+    records = _records(bank, "Orion means", authorized_speakers={"alice", "bob"})
+    speakers = {row["metadata"].get("speaker") for row in records}
+    passed = len(records) == 2 and speakers == {"alice", "bob"}
+    return passed, 3, ["same term retained both speaker attributions for clarification"]
+
+
+_CASE_HANDLERS: dict[str, Callable[[MemoryBank], tuple[bool, int, list[str]]]] = {
+    "speaker-belief-isolation": _speaker_belief_isolation,
+    "speaker-update": _speaker_update,
+    "private-leakage": _private_leakage,
+    "audience-language": _audience_language,
+    "term-ambiguity": _term_ambiguity,
+}
+
+
+def run_case(mode: str, case: dict[str, Any]) -> dict[str, Any]:
+    """Run one fixture case and return the benchmark runner contract."""
+    case_id = str(case.get("id", "")).strip()
+    handler = _CASE_HANDLERS.get(case_id)
+    if handler is None:
+        raise ValueError(f"unsupported fixture case: {case_id}")
+    started = time.perf_counter()
+    bank = MemoryBank(
+        _database_for(mode), user_id=f"benchmark-{mode}",
+        workspace_id=WORKSPACE_ID, session_id=case_id,
+    )
+    bank.store.append_event(
+        "benchmark.case_started",
+        {"case_id": case_id, "mode": mode, "provider": PROVIDER, "model": MODEL},
+        user_id=bank.user_id, workspace_id=bank.workspace_id, session_id=bank.session_id,
+    )
+    passed, tool_calls, checks = handler(bank)
+    events = bank.store.list_events(
+        workspace_id=bank.workspace_id, session_id=bank.session_id, user_id=bank.user_id,
+        limit=100,
+    )
+    memories = bank.store.list_memories(
+        workspace_id=bank.workspace_id, session_id=bank.session_id, user_id=bank.user_id,
+        status="active", limit=100,
+    )
+    if passed and events and memories:
+        evidence_status = "fixture_verified"
+    elif not passed:
+        evidence_status = "failed"
+    else:
+        evidence_status = "insufficient"
+    return {
+        "verified_success": passed,
+        "corrections": 1 if case_id == "speaker-update" else 0,
+        "repeated_errors": 0,
+        "tool_calls": tool_calls,
+        "tokens": max(1, len(str(case.get("task", ""))) + sum(len(row["content"]) for row in memories)),
+        "latency": max(0.0, time.perf_counter() - started),
+        "provider": PROVIDER,
+        "model": MODEL,
+        "evidence_status": evidence_status,
+        "evidence": {
+            "event_count": len(events),
+            "active_memory_count": len(memories),
+            "scope": {"user_id": bank.user_id, "workspace_id": bank.workspace_id, "session_id": case_id},
+            "checks": checks if passed else [],
+        },
+    }
+
+
+def run_stdin_case(mode: str) -> None:
+    case = json.load(sys.stdin)
+    if not isinstance(case, dict):
+        raise ValueError("benchmark input must be a JSON object")
+    result = run_case(mode, case)
+    print(json.dumps(result, ensure_ascii=False, separators=(",", ":")))

--- a/learning_benchmark.py
+++ b/learning_benchmark.py
@@ -13,6 +13,7 @@ from typing import Any
 
 PROTOCOL = "openkyrozen-learning-benchmark-v1"
 RESULT_FIELDS = {"verified_success", "corrections", "repeated_errors", "tool_calls", "tokens", "latency"}
+DEFAULT_EVIDENCE_STATUS = "verified"
 
 
 def _wilson(successes: int, total: int) -> tuple[float, float]:
@@ -44,10 +45,20 @@ def _run(command: str, case: dict[str, Any], timeout: float) -> dict[str, Any]:
     result = json.loads(completed.stdout)
     if not isinstance(result, dict) or not RESULT_FIELDS <= result.keys():
         raise ValueError(f"runner output must contain {sorted(RESULT_FIELDS)}")
-    return {"case_id": case["id"], "profile": case["profile"],
-            "verified_success": bool(result["verified_success"]),
-            **{field: max(0, int(result[field])) for field in ("corrections", "repeated_errors", "tool_calls", "tokens")},
-            "latency": max(0.0, float(result["latency"]))}
+    result_row = {"case_id": case["id"], "profile": case["profile"],
+                  "verified_success": bool(result["verified_success"]),
+                  **{field: max(0, int(result[field])) for field in ("corrections", "repeated_errors", "tool_calls", "tokens")},
+                  "latency": max(0.0, float(result["latency"]))}
+    for field in ("provider", "model", "evidence_status"):
+        value = result.get(field, DEFAULT_EVIDENCE_STATUS if field == "evidence_status" else "unknown")
+        result_row[field] = str(value)[:120]
+    evidence = result.get("evidence")
+    if isinstance(evidence, dict):
+        result_row["evidence"] = {
+            str(key)[:80]: (value if isinstance(value, (bool, int, float)) else str(value)[:500])
+            for key, value in list(evidence.items())[:20]
+        }
+    return result_row
 
 
 def summarize(results: list[dict[str, Any]]) -> dict[str, Any]:
@@ -58,7 +69,10 @@ def summarize(results: list[dict[str, Any]]) -> dict[str, Any]:
             "completion_rate": successes / total if total else None,
             "completion_rate_95ci": [low, high],
             **{field: sum(item[field] for item in results)
-               for field in ("corrections", "repeated_errors", "tool_calls", "tokens", "latency")}}
+               for field in ("corrections", "repeated_errors", "tool_calls", "tokens", "latency")},
+            "providers": sorted({str(item.get("provider", "unknown")) for item in results}),
+            "models": sorted({str(item.get("model", "unknown")) for item in results}),
+            "evidence_statuses": sorted({str(item.get("evidence_status", DEFAULT_EVIDENCE_STATUS)) for item in results})}
 
 
 def _sign_test_improvement(before: list[float], after: list[float]) -> dict[str, Any]:
@@ -86,10 +100,18 @@ def compare(clean: dict[str, Any], evolved: dict[str, Any],
                 [float(item[field]) for item in evolved_results],
             ))
     credible_secondary_gain = any(item.get("credible_improvement", False) for item in secondary.values())
+    evidence_sufficient = True
+    if clean_results is not None and evolved_results is not None:
+        evidence_sufficient = all(
+            item.get("evidence_status", DEFAULT_EVIDENCE_STATUS) == DEFAULT_EVIDENCE_STATUS
+            for item in [*clean_results, *evolved_results]
+        )
     return {"completion_non_regressing": evolved_rate is not None and clean_rate is not None and evolved_rate >= clean_rate,
             "credible_secondary_gain": credible_secondary_gain,
             "public_superiority_claim_supported": evolved_rate is not None and clean_rate is not None
-                                                   and evolved_rate >= clean_rate and credible_secondary_gain,
+                                                   and evolved_rate >= clean_rate and credible_secondary_gain
+                                                   and evidence_sufficient,
+            "paired_evidence_status": "verified" if evidence_sufficient else "insufficient",
             "secondary": secondary}
 
 
@@ -111,6 +133,20 @@ def main(argv: list[str] | None = None) -> None:
               "clean": {"summary": clean_summary, "results": clean},
               "evolved": {"summary": evolved_summary, "results": evolved},
               "comparison": compare(clean_summary, evolved_summary, clean, evolved)}
+    report["metadata"] = {
+        "cases": str(args.cases.resolve()),
+        "timeout_seconds": args.timeout,
+        "runners": {
+            "clean": {"command": args.clean_runner, "providers": clean_summary["providers"],
+                       "models": clean_summary["models"], "evidence_statuses": clean_summary["evidence_statuses"]},
+            "evolved": {"command": args.evolved_runner, "providers": evolved_summary["providers"],
+                         "models": evolved_summary["models"], "evidence_statuses": evolved_summary["evidence_statuses"]},
+        },
+        "evidence_policy": (
+            "A public superiority claim requires verified paired evidence from the same fixture, "
+            "provider, model, configuration, and independently observable product behavior."
+        ),
+    }
     report["ablations"] = {}
     for spec in args.ablation:
         name, separator, command = spec.partition("=")

--- a/tests/test_learning_benchmark.py
+++ b/tests/test_learning_benchmark.py
@@ -1,4 +1,6 @@
+import os
 import json
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -32,6 +34,33 @@ class LearningBenchmarkTests(unittest.TestCase):
             main(["--cases", str(cases), "--clean-runner", command, "--evolved-runner", command,
                   "--ablation", f"no-memory={command}", "--output", str(output)])
             self.assertIn("no-memory", json.loads(output.read_text())["ablations"])
+
+    def test_make_target_runs_repository_fixture_with_isolated_evidence(self):
+        repository = Path(__file__).parents[1]
+        with tempfile.TemporaryDirectory() as home:
+            env = os.environ.copy()
+            env["HOME"] = home
+            env["KYROZEN_DISABLE_VECTOR_INDEX"] = "1"
+            for variable in ("KYROZEN_PROVIDER", "KYROZEN_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY",
+                             "ANTHROPIC_API_KEY", "GEMINI_API_KEY", "KYROZEN_DB_PATH"):
+                env.pop(variable, None)
+            result = subprocess.run(
+                ["make", "benchmark"], cwd=repository, env=env,
+                capture_output=True, text=True, timeout=120,
+            )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        report = json.loads(result.stdout)
+        self.assertEqual(report["protocol"], "openkyrozen-learning-benchmark-v1")
+        self.assertEqual(report["case_order"], [
+            "speaker-belief-isolation", "speaker-update", "private-leakage",
+            "audience-language", "term-ambiguity",
+        ])
+        self.assertEqual(report["clean"]["summary"]["verified_successes"], 5)
+        self.assertEqual(report["evolved"]["summary"]["verified_successes"], 5)
+        self.assertEqual(report["metadata"]["runners"]["clean"]["providers"], ["deterministic-fixture"])
+        self.assertEqual(report["metadata"]["runners"]["evolved"]["models"], ["openkyrozen-memory-policy-v1"])
+        self.assertEqual(report["comparison"]["paired_evidence_status"], "insufficient")
+        self.assertFalse(report["comparison"]["public_superiority_claim_supported"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ship clean and evolved runner examples for the repository's frozen multi-party memory fixture
- add `make benchmark` with temporary, separate SQLite state and a clear dependency prerequisite
- include bounded provider/model/evidence metadata in benchmark reports
- prevent fixture-only output from being treated as a product superiority claim

## Validation
- `make benchmark` (5 fixture cases, both isolated runners, real SQLite evidence)
- `make check`
- `make lint`
- `make test` (119 tests)
- `git diff --check`

Fixes #21