### PR TITLE
fix: stop deleting dependency bytecode on startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,8 +3,6 @@ Kyrozen: self-learning AI Agent powered by DeepSeek API + tools.
 (Run `python main.py` to launch the agent)
 """
 
-import pathlib
-import shutil
 import sys
 import warnings
 
@@ -56,10 +54,6 @@ _UNICODE_OK = _terminal_supports_unicode()
 # Dual character sets: Unicode preferred, ASCII fallback for legacy terminals
 if _UNICODE_OK:    _SPINNER_FRAMES = ["◜", "◠", "◝", "◞", "◡", "◟"]; _BAR_FILL = "█"; _BAR_EMPTY = "░"; _CHECK = "✓"; _CIRCLE = "○"; _HALF = "◷"; _BOX_TL = "┌"; _BOX_H = "─"; _BOX_BL = "└"; _BOX_V = "│"; _DOT = "·"; _NBHYPHEN = "‑"
 else:               _SPINNER_FRAMES = ["/", "-", "\\", "|"];             _BAR_FILL = "#"; _BAR_EMPTY = "."; _CHECK = "+"; _CIRCLE = "o"; _HALF = ">"; _BOX_TL = "+"; _BOX_H = "-"; _BOX_BL = "+"; _BOX_V = "|"; _DOT = "."; _NBHYPHEN = "-"
-
-# Delete stale __pycache__ before any imports to avoid loading deprecated bytecode
-for p in pathlib.Path(__file__).parent.rglob("__pycache__"):
-    shutil.rmtree(p, ignore_errors=True)
 
 import ast
 import json
@@ -4756,7 +4750,6 @@ def _run_recovered_tasks(*, max_tasks: int = 20) -> list[dict[str, Any]]:
 
 
 def main() -> None:
-    # Bytecode cache cleared already at module level (see top of file)
     global _provider_config, llm_provider, DEEPSEEK_MODEL, DEEPSEEK_MODEL_SIMPLE, DEEPSEEK_MODEL_COMPLEX, MODEL_NAME
     global _agent_profile_mode
 

--- a/tests/test_startup_cache.py
+++ b/tests/test_startup_cache.py
@@ -1,0 +1,93 @@
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+STARTUP_TIMEOUT_SECONDS = 30
+_CREDENTIAL_ENV_VARS = (
+    "KYROZEN_API_KEY",
+    "DEEPSEEK_API_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GEMINI_API_KEY",
+)
+
+
+class StartupCacheTests(unittest.TestCase):
+    def _run_startup(self, command: list[str], *, input_text: str = "") -> None:
+        repository = Path(__file__).parents[1].resolve()
+        with tempfile.TemporaryDirectory(
+            prefix=".openkyrozen-startup-cache-", dir=repository
+        ) as fixture_dir, tempfile.TemporaryDirectory() as home_dir, tempfile.TemporaryDirectory() as state_dir:
+            # This models a dependency cache below the checkout.  The old
+            # startup cleanup deleted it even though OpenKyrozen did not own it.
+            sentinel = (
+                Path(fixture_dir)
+                / "venv"
+                / "lib"
+                / "python3.12"
+                / "site-packages"
+                / "dependency"
+                / "__pycache__"
+                / "dependency.cpython-312.pyc"
+            )
+            sentinel.parent.mkdir(parents=True)
+            sentinel.write_bytes(b"dependency-bytecode-sentinel")
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "HOME": home_dir,
+                    "KYROZEN_PROVIDER": "ollama",
+                    "KYROZEN_DB_PATH": str(Path(state_dir) / "startup.sqlite3"),
+                    "KYROZEN_DISABLE_VECTOR_INDEX": "1",
+                    "KYROZEN_EXECUTION_SURFACE": "cli",
+                    "KYROZEN_TURN_LOG": str(Path(state_dir) / "turns.log"),
+                    "PYTHONPATH": os.pathsep.join(
+                        part for part in (str(repository), env.get("PYTHONPATH", "")) if part
+                    ),
+                }
+            )
+            for variable in _CREDENTIAL_ENV_VARS:
+                env.pop(variable, None)
+
+            started = time.monotonic()
+            result = subprocess.run(
+                command,
+                cwd=repository,
+                env=env,
+                input=input_text,
+                capture_output=True,
+                text=True,
+                timeout=STARTUP_TIMEOUT_SECONDS,
+            )
+            elapsed = time.monotonic() - started
+
+            output = result.stdout + result.stderr
+            self.assertEqual(result.returncode, 0, output)
+            self.assertLess(
+                elapsed,
+                STARTUP_TIMEOUT_SECONDS,
+                f"startup exceeded {STARTUP_TIMEOUT_SECONDS}s:\n{output}",
+            )
+            self.assertTrue(sentinel.is_file(), "startup deleted a dependency cache")
+            self.assertEqual(sentinel.read_bytes(), b"dependency-bytecode-sentinel")
+
+    def test_cli_startup_is_bounded_and_preserves_dependency_bytecode(self):
+        self._run_startup([sys.executable, "main.py"], input_text="/quit\n")
+
+    def test_web_startup_is_bounded_and_preserves_dependency_bytecode(self):
+        script = (
+            "import asyncio; import server; "
+            "asyncio.run(server.startup()); "
+            "asyncio.run(server.shutdown()); print('web-startup-ready')"
+        )
+        self._run_startup([sys.executable, "-c", script])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #50

Remove the repository-wide startup deletion of every __pycache__ tree and its unused imports. Add bounded real CLI and FastAPI startup tests using keyless Ollama configuration and an in-checkout dependency-cache sentinel; both verify the sentinel survives startup.

Validation:
- ./venv/bin/python -m unittest tests.test_startup_cache -v (2 tests, real CLI/Web startup)
- make check
- make lint
- KYROZEN_BROWSER_ALLOW_PRIVATE=1 make test (124 tests)
- git diff --check
- PR head ad55c8b is GPG-signed and GitHub verified.