### PR TITLE
fix: parse git remote arguments safely

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,4 +1,5 @@
 import tempfile
+import subprocess
 import unittest
 import os
 import sys
@@ -8,7 +9,16 @@ from unittest.mock import patch
 from pathlib import Path
 
 import tools
-from tools import AVAILABLE_TOOLS, allowed_tool_names, read_file, read_webpage, run_cmd, set_workspace_root, write_file
+from tools import (
+    AVAILABLE_TOOLS,
+    allowed_tool_names,
+    git_remote,
+    read_file,
+    read_webpage,
+    run_cmd,
+    set_workspace_root,
+    write_file,
+)
 
 
 class WorkspaceToolTests(unittest.TestCase):
@@ -42,6 +52,42 @@ class WorkspaceToolTests(unittest.TestCase):
         with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}, clear=False):
             result = run_cmd(f"{sys.executable} -c 'print(\"explicit\")'")
         self.assertEqual(result, "explicit")
+
+    def test_git_remote_add_list_and_remove_use_real_repository(self):
+        with tempfile.TemporaryDirectory() as directory:
+            repository = Path(directory)
+            initialized = subprocess.run(
+                ["git", "init", "--quiet", str(repository)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(initialized.returncode, 0, initialized.stderr)
+            remote_url = "https://example.com/org/repo.git?token=x&format=json"
+            with patch("tools.os.getcwd", return_value=str(repository)):
+                added = git_remote(f"add origin {remote_url}")
+                listed = git_remote("")
+                removed = git_remote("remove origin")
+                after_remove = git_remote("")
+            self.assertEqual(added, "Remote 'origin' added.")
+            self.assertIn(f"origin\t{remote_url} (fetch)", listed)
+            self.assertIn(f"origin\t{remote_url} (push)", listed)
+            self.assertEqual(removed, "Remote 'origin' removed.")
+            self.assertEqual(after_remove, "(no remotes configured)")
+
+    def test_git_remote_rejects_malformed_arguments_deterministically(self):
+        self.assertEqual(
+            git_remote("add origin"),
+            "Error: git_remote add requires exactly: add <name> <url>.",
+        )
+        self.assertEqual(
+            git_remote("remove origin extra"),
+            "Error: git_remote remove requires exactly: remove <name>.",
+        )
+        self.assertEqual(
+            git_remote("add origin 'unterminated"),
+            "Error: git_remote arguments contain invalid shell quoting.",
+        )
 
     def test_read_webpage_blocks_private_and_reserved_destinations_before_connecting(self):
         class PrivateHandler(BaseHTTPRequestHandler):

--- a/tools.py
+++ b/tools.py
@@ -3,6 +3,7 @@ Agent capabilities: file I/O, shell commands, web search.
 """
 
 import os
+import shlex
 import subprocess
 import re
 import glob
@@ -638,15 +639,36 @@ def git_remote(args: str) -> str:
     """
     try:
         dir_path = "."
-        cmd = ["git", "-C", os.path.abspath(os.path.expanduser(dir_path)), "remote", "-v"]
-        if args.strip():
-            action_parts = args.strip().split(maxsplit=1)
-            cmd = ["git", "-C", os.path.abspath(os.path.expanduser(dir_path)), "remote"]
-            cmd.extend(action_parts)
+        git_dir = os.path.abspath(os.path.expanduser(dir_path))
+        try:
+            parts = shlex.split(args or "")
+        except ValueError:
+            return "Error: git_remote arguments contain invalid shell quoting."
+
+        cmd = ["git", "-C", git_dir, "remote"]
+        if not parts:
+            cmd.append("-v")
+        elif parts[0] == "add":
+            if len(parts) != 3:
+                return "Error: git_remote add requires exactly: add <name> <url>."
+            cmd.extend(parts)
+        elif parts[0] == "remove":
+            if len(parts) != 2:
+                return "Error: git_remote remove requires exactly: remove <name>."
+            cmd.extend(parts)
+        else:
+            return "Error: git_remote requires empty args, add <name> <url>, or remove <name>."
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
         if result.returncode != 0:
             return f"Git remote failed:\n{result.stderr}"
-        return result.stdout.strip() or "(no remotes configured)"
+        output = result.stdout.strip()
+        if output:
+            return output
+        if parts and parts[0] == "add":
+            return f"Remote '{parts[1]}' added."
+        if parts and parts[0] == "remove":
+            return f"Remote '{parts[1]}' removed."
+        return "(no remotes configured)"
     except Exception as e:
         return f"Error running git remote: {e}"
 


### PR DESCRIPTION
Fixes #52

Parse git_remote arguments with shlex and validate the supported empty-list, add name URL, and remove name forms before invoking Git. URLs retain punctuation and successful add/remove operations report deterministic results.

Validation:
- ./venv/bin/python -m unittest tests.test_tools -v (real temporary Git repository add/list/remove)
- make check
- make lint
- make test (127 tests)
- git diff --check
- PR head 1e6c1e4 is GPG-signed and GitHub verified.