### PR TITLE
fix: complete private claim lifecycle

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -392,6 +392,23 @@ OpenKyrozen v2 の長期メモリは **SQLite を事実上のソース**（`~/.k
 
 タスクは再起動後も保存され、状態は `pending`、`running`、`succeeded`、`failed`、`blocked`、`cancelled` です（旧 `done` は読取互換）。`TaskDone` だけでは成功にならず、ツール結果、テスト、ファイル確認、または明示的な確認の証拠が必要です。安全な API タスクは worker が再開し、failed/blocked タスクは `/api/v2/tasks/{task_id}/resume` で明示的に再開します。
 
+プライベート claim は `speaker` を省略すると `KYROZEN_SERVER_ACTOR`（既定値
+`local`）に紐付きます。安定した actor を設定し、create → list → detail → forget
+を同じデプロイで実行できます：
+
+```bash
+export KYROZEN_SERVER_ACTOR=owner-66
+curl -sS -X POST http://127.0.0.1:8000/api/v2/memory/claims \
+  -H 'Content-Type: application/json' \
+  -d '{"key":"favorite editor","value":"vim","claim_type":"private_fact","authority":"owner"}'
+curl -sS http://127.0.0.1:8000/api/v2/memory/claims
+curl -sS http://127.0.0.1:8000/api/v2/memory/claims/<claim_id>
+curl -sS -X DELETE http://127.0.0.1:8000/api/v2/memory/claims/<claim_id>
+```
+
+別の `speaker` を明示しても attribution filter に過ぎず、private claim の読取や
+削除はできません。
+
 ---
 
 ## 🌐 Web UI と REST API

--- a/README.ko.md
+++ b/README.ko.md
@@ -392,6 +392,22 @@ OpenKyrozen v2의 장기 메모리는 **SQLite를 사실의 원본**(`~/.kyrozen
 
 작업은 재시작 후에도 저장되며 상태는 `pending`, `running`, `succeeded`, `failed`, `blocked`, `cancelled`입니다(이전 `done`은 읽기 호환). `TaskDone`만으로는 성공하지 않고 도구 결과, 테스트, 파일 확인 또는 명시적 확인 증거가 필요합니다. 안전한 API 작업은 worker가 재개하며 failed/blocked 작업은 `/api/v2/tasks/{task_id}/resume`으로 명시적으로 재개합니다.
 
+private claim은 `speaker`를 생략하면 `KYROZEN_SERVER_ACTOR`(기본값 `local`)에
+연결됩니다. 안정적인 actor를 설정하고 같은 배포에서 create → list → detail →
+forget 전체 수명 주기를 실행할 수 있습니다.
+
+```bash
+export KYROZEN_SERVER_ACTOR=owner-66
+curl -sS -X POST http://127.0.0.1:8000/api/v2/memory/claims \
+  -H 'Content-Type: application/json' \
+  -d '{"key":"favorite editor","value":"vim","claim_type":"private_fact","authority":"owner"}'
+curl -sS http://127.0.0.1:8000/api/v2/memory/claims
+curl -sS http://127.0.0.1:8000/api/v2/memory/claims/<claim_id>
+curl -sS -X DELETE http://127.0.0.1:8000/api/v2/memory/claims/<claim_id>
+```
+
+다른 `speaker`를 명시해도 attribution filter일 뿐이며 private claim을 읽거나 삭제할 수 없습니다.
+
 ---
 
 ## 🌐 Web UI 및 REST API

--- a/README.md
+++ b/README.md
@@ -479,7 +479,25 @@ Selection ranks relevant guidance by verified utility per context character and 
 
 Learned guidance is bound to the provider/model family that produced its evidence unless paired replay validates it across models. Verifier reliability, evidence-adaptive review priority, and a user-owned `KYROZEN_LEARNING_CONSTITUTION` file constrain evolution. Redacted experience capsules are portable JSON evidence, but imports always remain inactive candidates until local validation.
 
-Multi-party claims distinguish attributed beliefs, private facts, and group agreements. Speaker, audience, channel, and visibility checks run before recall; private claims require the authenticated request actor, not a client-supplied speaker label. Chat responses include a memory receipt listing the claim IDs and speakers that affected the turn, and `benchmarks/multi_party_memory.jsonl` provides frozen leakage, update, ambiguity, and audience cases.
+Multi-party claims distinguish attributed beliefs, private facts, and group agreements. Speaker, audience, channel, and visibility checks run before recall; private claims use the configured `KYROZEN_SERVER_ACTOR`, not a client-supplied speaker label. Chat responses include a memory receipt listing the claim IDs and speakers that affected the turn, and `benchmarks/multi_party_memory.jsonl` provides frozen leakage, update, ambiguity, and audience cases.
+
+For a private claim, omit `speaker` and use the same deployment actor for the full
+create → list → detail → forget lifecycle. Set a stable actor label when using a
+custom deployment (the default is `local`):
+
+```bash
+export KYROZEN_SERVER_ACTOR=owner-66
+curl -sS -X POST http://127.0.0.1:8000/api/v2/memory/claims \
+  -H 'Content-Type: application/json' \
+  -d '{"key":"favorite editor","value":"vim","claim_type":"private_fact","authority":"owner"}'
+curl -sS http://127.0.0.1:8000/api/v2/memory/claims
+curl -sS http://127.0.0.1:8000/api/v2/memory/claims/<claim_id>
+curl -sS -X DELETE http://127.0.0.1:8000/api/v2/memory/claims/<claim_id>
+```
+
+An explicit different `speaker` is only an attribution filter and cannot read or
+delete the private claim. Use separate deployments and databases for separate
+private users.
 
 ### Memory storage
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -405,6 +405,22 @@ python main.py migrate v1 ./chroma_memory
 
 Web/MCP 是单用户部署：一个 `KYROZEN_SERVER_TOKEN` 代表该部署唯一的私有 actor；请求体中的 `speaker` 不能伪造私有身份。私有记忆、任务、事件、计划和学习状态按该 actor、workspace、session 作用域隔离；共享部署的多个私有用户应使用不同部署和数据库。
 
+私有声明的完整生命周期不需要重复传入 `speaker`：未提供时使用
+`KYROZEN_SERVER_ACTOR`（默认 `local`）。设置稳定 actor 后，可按 create → list →
+detail → forget 执行：
+
+```bash
+export KYROZEN_SERVER_ACTOR=owner-66
+curl -sS -X POST http://127.0.0.1:8000/api/v2/memory/claims \
+  -H 'Content-Type: application/json' \
+  -d '{"key":"favorite editor","value":"vim","claim_type":"private_fact","authority":"owner"}'
+curl -sS http://127.0.0.1:8000/api/v2/memory/claims
+curl -sS http://127.0.0.1:8000/api/v2/memory/claims/<claim_id>
+curl -sS -X DELETE http://127.0.0.1:8000/api/v2/memory/claims/<claim_id>
+```
+
+显式提供其他 `speaker` 只能作为归属过滤，不能读取或删除该私有声明。
+
 ---
 
 ## 🌐 Web UI 与 REST API

--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -157,12 +157,25 @@ curl -sS 'http://127.0.0.1:8000/api/v2/memory/claims?speaker=alice&audience=ops&
 An attributed belief is always rendered with its speaker and does not resolve
 to an unattributed value when speakers disagree. A private fact requires
 `authority=owner` and is never exposed through unscoped recall. Private API
-claims must name the authenticated request actor: `loopback` for an
-unauthenticated loopback server, or `authenticated` when
-`KYROZEN_SERVER_TOKEN` is enabled. A client-supplied label such as `alice` is
-an attribution, not an authorization grant. Deployments that need distinct
-human identities or group membership must enforce that mapping at their
-authentication or proxy layer.
+claims use the stable `KYROZEN_SERVER_ACTOR` configured for the deployment;
+omitting `speaker` uses that actor for create, list, detail, and forget. A
+client-supplied label such as `alice` is an attribution/filter, not an
+authorization grant. Deployments that need distinct human identities or group
+membership must use separate deployments and databases or enforce that mapping
+at their authentication/proxy layer.
+
+Use the same deployment actor for a complete private-claim lifecycle (the
+default actor is `local`):
+
+```bash
+export KYROZEN_SERVER_ACTOR=owner-66
+curl -sS -X POST http://127.0.0.1:8000/api/v2/memory/claims \
+  -H 'Content-Type: application/json' \
+  -d '{"key":"favorite editor","value":"vim","claim_type":"private_fact","authority":"owner"}'
+curl -sS http://127.0.0.1:8000/api/v2/memory/claims
+curl -sS http://127.0.0.1:8000/api/v2/memory/claims/<claim_id>
+curl -sS -X DELETE http://127.0.0.1:8000/api/v2/memory/claims/<claim_id>
+```
 
 `GET /api/v2/events?event_type=memory.recalled` shows the receipt payload used
 for a turn. Learning events such as `learning.outcome`,

--- a/event_store.py
+++ b/event_store.py
@@ -412,13 +412,21 @@ class EventStore:
         return result
 
     def update_proposal(self, proposal_id: str, *, status: str, validation: dict[str, Any] | None = None,
-                        confidence: float | None = None) -> bool:
-        values = [status, self._json(validation or {}), utc_now(), proposal_id]
+                        confidence: float | None = None, workspace_id: str | None = None,
+                        user_id: str | None = None) -> bool:
+        values = [status, self._json(validation or {}), utc_now()]
         query = "UPDATE learning_proposals SET status=?,validation=?,updated_at=?"
         if confidence is not None:
             query += ",confidence=?"
-            values.insert(-1, max(0.0, min(1.0, confidence)))
+            values.append(max(0.0, min(1.0, confidence)))
         query += " WHERE id=?"
+        values.append(proposal_id)
+        if workspace_id is not None:
+            query += " AND workspace_id=?"
+            values.append(workspace_id)
+        if user_id is not None:
+            query += " AND user_id=?"
+            values.append(user_id)
         with self._lock, self.connection() as db:
             return db.execute(query, values).rowcount == 1
 

--- a/learning_engine.py
+++ b/learning_engine.py
@@ -429,7 +429,8 @@ class LearningEngine:
                     "claim_type": claim_type, "speaker": speaker, "audiences": audiences,
                     "channel": self._clean(channel or "") or None, "visibility": visibility}
         active = [row for row in self.store.list_memories(status="active", limit=10000,
-                                                          workspace_id=self.memory.workspace_id)
+                                                          workspace_id=self.memory.workspace_id,
+                                                          user_id=self.memory.user_id)
                   if row.get("metadata", {}).get("claim_key") == key
                   and row.get("metadata", {}).get("scope") == metadata["scope"]
                   and row.get("metadata", {}).get("speaker") == speaker
@@ -445,7 +446,9 @@ class LearningEngine:
         if authority == "owner":
             for row in active:
                 if row.get("metadata", {}).get("claim_value") != value:
-                    self.store.set_memory_status(row["id"], "superseded", workspace_id=self.memory.workspace_id)
+                    self.store.set_memory_status(row["id"], "superseded",
+                                                 workspace_id=self.memory.workspace_id,
+                                                 user_id=self.memory.user_id)
                     metadata["supersedes"] = row["id"]
             memory_id = self.memory.add_log(display, kind=kind, status="active", confidence=1.0,
                                             metadata=metadata)
@@ -494,7 +497,9 @@ class LearningEngine:
                    "speaker": speaker, "audience": audience, "channel": channel}
         authorized_speakers = authorized_speakers or set()
         matches = []
-        for row in self.store.list_memories(status="active", limit=10000, workspace_id=self.memory.workspace_id):
+        for row in self.store.list_memories(status="active", limit=10000,
+                                            workspace_id=self.memory.workspace_id,
+                                            user_id=self.memory.user_id):
             meta = row.get("metadata", {})
             if not meta.get("claim") or meta.get("claim_key") != key:
                 continue
@@ -523,30 +528,48 @@ class LearningEngine:
                     next(iter(values)) if len(values) == 1 else None),
                 "attributed_values": attributed, "claims": best, "scope_rank": best_rank[0]}
 
-    def explain_claim(self, claim_id: str) -> dict[str, Any] | None:
-        rows = self.store.list_memories(status=None, limit=10000, workspace_id=self.memory.workspace_id)
+    def explain_claim(self, claim_id: str, *, user_id: str | None = None,
+                      workspace_id: str | None = None, session_id: str | None = None) -> dict[str, Any] | None:
+        scoped_user = self.memory.user_id if user_id is None else str(user_id)
+        scoped_workspace = self.memory.workspace_id if workspace_id is None else str(workspace_id)
+        rows = self.store.list_memories(status=None, limit=10000,
+                                        workspace_id=scoped_workspace, session_id=session_id,
+                                        user_id=scoped_user)
         row = next((item for item in rows if item["id"] == claim_id and item.get("metadata", {}).get("claim")), None)
         return row
 
-    def forget_claim(self, claim_id: str) -> bool:
-        claim = self.explain_claim(claim_id)
+    def forget_claim(self, claim_id: str, *, user_id: str | None = None,
+                     workspace_id: str | None = None, session_id: str | None = None) -> bool:
+        scoped_user = self.memory.user_id if user_id is None else str(user_id)
+        scoped_workspace = self.memory.workspace_id if workspace_id is None else str(workspace_id)
+        scoped_session = self.memory.session_id if session_id is None else session_id
+        claim = self.explain_claim(claim_id, user_id=scoped_user,
+                                   workspace_id=scoped_workspace, session_id=scoped_session)
         if not claim:
             return False
-        self.memory.delete_logs([claim_id])
-        for proposal in self.store.list_proposals(workspace_id=self.memory.workspace_id, limit=10000):
+        claim_memory = self.memory
+        if (scoped_user, scoped_workspace, scoped_session) != (
+                self.memory.user_id, self.memory.workspace_id, self.memory.session_id):
+            claim_memory = MemoryBank(self.memory.db_path, user_id=scoped_user,
+                                      workspace_id=scoped_workspace, session_id=scoped_session)
+        claim_memory.delete_logs([claim_id])
+        for proposal in self.store.list_proposals(workspace_id=scoped_workspace, user_id=scoped_user, limit=10000):
             if claim_id not in proposal.get("validation", {}).get("dependencies", []):
                 continue
             skill_id = proposal.get("validation", {}).get("skill_id")
             if skill_id and self.registry:
                 self.registry.rollback_learned(skill_id)
-            self.store.update_proposal(proposal["id"], status="rejected",
-                                       validation={**proposal["validation"], "reason": "source claim deleted"})
+            self.store.update_proposal(
+                proposal["id"], status="rejected",
+                validation={**proposal["validation"], "reason": "source claim deleted"},
+                workspace_id=scoped_workspace, user_id=scoped_user,
+            )
         self.store.append_event("memory.claim_forgotten", {"memory_id": claim_id},
-                                user_id=self.memory.user_id, workspace_id=self.memory.workspace_id,
-                                session_id=self.memory.session_id)
+                                user_id=scoped_user, workspace_id=scoped_workspace,
+                                session_id=scoped_session)
         self.store.append_event("learning.regression_cases_deactivated", {"dependency": claim_id},
-                                user_id=self.memory.user_id, workspace_id=self.memory.workspace_id,
-                                session_id=self.memory.session_id)
+                                user_id=scoped_user, workspace_id=scoped_workspace,
+                                session_id=scoped_session)
         return True
 
     def negative_preflight(self, profile: str, task: str) -> list[dict[str, Any]]:

--- a/memory.py
+++ b/memory.py
@@ -265,8 +265,7 @@ class MemoryBank:
                 continue
             audiences = set(metadata.get("audiences", []))
             visibility = metadata.get("visibility", "public")
-            if visibility == "private" and not (
-                    claim_speaker == speaker and claim_speaker in authorized_speakers):
+            if visibility == "private" and claim_speaker not in authorized_speakers:
                 continue
             if visibility == "group" and audiences and audience not in audiences:
                 continue

--- a/server.py
+++ b/server.py
@@ -697,10 +697,13 @@ async def api_v2_create_memory_claim(request: Request):
 async def api_v2_memory_claim(request: Request, claim_id: str, speaker: str | None = None,
                               audience: str | None = None, channel: str | None = None):
     speaker, audience, channel = _normalise_memory_context(speaker, audience, channel)
-    claim = _agent.learning_engine.explain_claim(claim_id)
+    actor = _actor_for_request(request)
+    claim = _agent.learning_engine.explain_claim(
+        claim_id, user_id=actor, workspace_id=_agent.memory_bank.workspace_id,
+    )
     visible = _agent.memory_bank.filter_records(
         [claim] if claim else [], speaker=speaker, audience=audience, channel=channel,
-        authorized_speakers={_actor_for_request(request)},
+        authorized_speakers={actor},
     )
     if not visible:
         raise HTTPException(404, "Memory claim not found")
@@ -708,8 +711,10 @@ async def api_v2_memory_claim(request: Request, claim_id: str, speaker: str | No
 
 
 @app.delete("/api/v2/memory/claims/{claim_id}", dependencies=[Depends(require_api_access)])
-async def api_v2_memory_forget_claim(claim_id: str):
-    if not _agent.learning_engine.forget_claim(claim_id):
+async def api_v2_memory_forget_claim(request: Request, claim_id: str):
+    actor = _actor_for_request(request)
+    if not _agent.learning_engine.forget_claim(
+            claim_id, user_id=actor, workspace_id=_agent.memory_bank.workspace_id):
         raise HTTPException(404, "Memory claim not found")
     return {"status": "forgotten", "memory_id": claim_id}
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,8 @@
 import os
 import asyncio
+import json
+import subprocess
+import sys
 import threading
 import tempfile
 import unittest
@@ -279,16 +282,99 @@ class ServerBoundaryTests(unittest.TestCase):
         self.assertIn(created.json()["memory_id"], [item["id"] for item in visible])
 
     def test_private_claim_without_speaker_is_bound_to_deployment_actor(self):
-        client = TestClient(server.app)
-        response = client.post("/api/v2/memory/claims", json={
-            "key": "private-api-default", "value": "deployment-owned", "claim_type": "private_fact",
-            "authority": "owner",
-        })
-        self.assertEqual(response.status_code, 200, response.text)
-        claim_id = response.json()["memory_id"]
-        visible = client.get("/api/v2/memory/claims",
-                             params={"speaker": server._SERVER_ACTOR_ID}).json()["claims"]
-        self.assertIn(claim_id, [item["id"] for item in visible])
+        repository = Path(__file__).parents[1].resolve()
+        script = """
+import json
+import os
+from fastapi.testclient import TestClient
+import server
+
+client = TestClient(server.app)
+claim_id = os.environ.get("CLAIM_ID")
+created_status = None
+if not claim_id:
+    created = client.post("/api/v2/memory/claims", json={
+        "key": "private-api-lifecycle", "value": "deployment-owned",
+        "claim_type": "private_fact", "authority": "owner",
+    })
+    created_status = created.status_code
+    claim_id = created.json().get("memory_id")
+listing = client.get("/api/v2/memory/claims")
+detail = client.get(f"/api/v2/memory/claims/{claim_id}") if claim_id else None
+wrong_speaker = client.get(
+    f"/api/v2/memory/claims/{claim_id}", params={"speaker": "different-actor"}
+) if claim_id else None
+forgotten = client.delete(f"/api/v2/memory/claims/{claim_id}") if claim_id else None
+after = client.get(f"/api/v2/memory/claims/{claim_id}") if claim_id else None
+print(json.dumps({
+    "actor": server._SERVER_ACTOR_ID,
+    "created": created_status,
+    "claim_id": claim_id,
+    "listed": listing.status_code == 200 and any(
+        item["id"] == claim_id for item in listing.json().get("claims", [])
+    ),
+    "detail": detail.status_code if detail else None,
+    "wrong_speaker": wrong_speaker.status_code if wrong_speaker else None,
+    "forgotten": forgotten.status_code if forgotten else None,
+    "after": after.status_code if after else None,
+}))
+"""
+
+        def run_actor(database: Path, actor: str | None, claim_id: str | None = None) -> dict:
+            with tempfile.TemporaryDirectory(prefix="openkyrozen-claim-home-") as home:
+                environment = os.environ.copy()
+                environment.update({
+                    "HOME": home,
+                    "KYROZEN_DB_PATH": str(database),
+                    "KYROZEN_DISABLE_VECTOR_INDEX": "1",
+                    "KYROZEN_PROVIDER": "ollama",
+                    "KYROZEN_EXECUTION_SURFACE": "web",
+                    "PYTHONPATH": str(repository),
+                })
+                environment.pop("KYROZEN_SERVER_TOKEN", None)
+                if actor is None:
+                    environment.pop("KYROZEN_SERVER_ACTOR", None)
+                else:
+                    environment["KYROZEN_SERVER_ACTOR"] = actor
+                if claim_id:
+                    environment["CLAIM_ID"] = claim_id
+                result = subprocess.run(
+                    [sys.executable, "-c", script], cwd=database.parent,
+                    env=environment, capture_output=True, text=True, timeout=30,
+                )
+                output = result.stdout + result.stderr
+                self.assertEqual(result.returncode, 0, output)
+                return json.loads(result.stdout.strip().splitlines()[-1])
+
+        with tempfile.TemporaryDirectory(prefix="openkyrozen-claim-api-") as directory:
+            root = Path(directory)
+            default = run_actor(root / "default.sqlite3", None)
+            self.assertEqual(default["actor"], "local")
+            self.assertEqual(default["created"], 200)
+            self.assertTrue(default["listed"])
+            self.assertEqual(default["detail"], 200)
+            self.assertEqual(default["wrong_speaker"], 404)
+            self.assertEqual(default["forgotten"], 200)
+            self.assertEqual(default["after"], 404)
+
+            owner = run_actor(root / "configured.sqlite3", "owner-66")
+            self.assertEqual(owner["actor"], "owner-66")
+            self.assertEqual(owner["created"], 200)
+            self.assertTrue(owner["listed"])
+            self.assertEqual(owner["detail"], 200)
+            self.assertEqual(owner["wrong_speaker"], 404)
+
+            other = run_actor(root / "configured.sqlite3", "other-66", owner["claim_id"])
+            self.assertEqual(other["actor"], "other-66")
+            self.assertFalse(other["listed"])
+            self.assertEqual(other["detail"], 404)
+            self.assertEqual(other["wrong_speaker"], 404)
+            self.assertEqual(other["forgotten"], 404)
+            self.assertEqual(other["after"], 404)
+
+            owner_after = run_actor(root / "configured.sqlite3", "owner-66", owner["claim_id"])
+            self.assertFalse(owner_after["listed"])
+            self.assertEqual(owner_after["detail"], 404)
 
     def test_server_actor_is_stable_across_authentication_modes(self):
         self.assertEqual(server._actor_for_request(None), server._SERVER_ACTOR_ID)


### PR DESCRIPTION
Fixes #66\n\nScopes private claim explain/forget and supporting SQLite operations by actor and workspace, makes the configured deployment actor the default private-claim visibility, and preserves public/group attribution behavior. Adds a real temporary-SQLite FastAPI subprocess regression for default/configured actors, wrong speaker filters, cross-actor read/delete denial, and post-forget 404s. Updates English, Chinese, Japanese, Korean, and self-evolution documentation with executable lifecycle examples.\n\nValidation: make check; make lint; make test (130); make docs-check; make shell-check; git diff --check.