### PR TITLE
fix: buffer browser chat SSE events

### DIFF
--- a/server.py
+++ b/server.py
@@ -496,31 +496,76 @@ async function sendMessage() {
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({message: msg, session_id: sessionId})
     });
+    if (!resp.ok || !resp.body) throw new Error('HTTP ' + resp.status);
     const reader = resp.body.getReader();
     const decoder = new TextDecoder();
     let full = '';
+    let sseBuffer = '';
+    const streamState = {done: false, error: false, parseError: false};
+
+    function handleSseEvent(eventText) {
+      const data = eventText.split(/\r?\n/)
+        .filter(line => line.startsWith('data:'))
+        .map(line => line.startsWith('data: ') ? line.slice(6) : line.slice(5))
+        .join('\n');
+      if (!data) return;
+      if (data === '[DONE]') {
+        streamState.done = true;
+        return;
+      }
+      try {
+        const parsed = JSON.parse(data);
+        if (Object.prototype.hasOwnProperty.call(parsed, 'chunk')) {
+          full += String(parsed.chunk);
+          contentDiv.textContent = full;
+        }
+        if (Object.prototype.hasOwnProperty.call(parsed, 'cost')) {
+          document.getElementById('cost-display').textContent = String(parsed.cost);
+        }
+        if (Object.prototype.hasOwnProperty.call(parsed, 'error')) {
+          streamState.error = true;
+          contentDiv.textContent = 'Error: ' + String(parsed.error);
+          contentDiv.classList.add('error');
+        }
+      } catch (e) {
+        streamState.parseError = true;
+        contentDiv.textContent = 'Stream parse error: ' + e.message;
+        contentDiv.classList.add('error');
+      }
+    }
+
+    function consumeSseText(text) {
+      sseBuffer += text;
+      while (true) {
+        const boundary = sseBuffer.match(/\r?\n\r?\n/);
+        if (!boundary) break;
+        const eventText = sseBuffer.slice(0, boundary.index);
+        sseBuffer = sseBuffer.slice(boundary.index + boundary[0].length);
+        handleSseEvent(eventText);
+      }
+    }
+
     while (true) {
       const {done, value} = await reader.read();
       if (done) break;
-      const chunk = decoder.decode(value);
-      for (const line of chunk.split('\n')) {
-        if (line.startsWith('data: ')) {
-          const data = line.slice(6);
-          if (data === '[DONE]') continue;
-          try {
-            const parsed = JSON.parse(data);
-            if (parsed.chunk) { full += parsed.chunk; contentDiv.textContent = full; }
-            if (parsed.cost) document.getElementById('cost-display').textContent = parsed.cost;
-            if (parsed.error) { contentDiv.textContent = 'Error: ' + parsed.error; contentDiv.classList.add('error'); }
-          } catch(e) {}
-        }
-      }
+      consumeSseText(decoder.decode(value, {stream: true}));
       document.getElementById('chat').scrollTop = document.getElementById('chat').scrollHeight;
     }
-    document.getElementById('status').textContent = 'Ready';
+    consumeSseText(decoder.decode());
+    if (sseBuffer.trim()) handleSseEvent(sseBuffer);
+    if (streamState.parseError) {
+      document.getElementById('status').textContent = 'Error';
+    } else if (streamState.done) {
+      document.getElementById('status').textContent = 'Ready';
+    } else if (streamState.error) {
+      document.getElementById('status').textContent = 'Error';
+    } else {
+      document.getElementById('status').textContent = 'Incomplete stream';
+    }
   } catch(e) {
     contentDiv.textContent = 'Connection error: ' + e.message;
     contentDiv.classList.add('error');
+    document.getElementById('status').textContent = 'Error';
   }
   isStreaming = false;
   btn.disabled = false;

--- a/tests/test_browser_manager.py
+++ b/tests/test_browser_manager.py
@@ -8,6 +8,7 @@ import unittest
 from unittest.mock import patch
 
 from browser_manager import BrowserManager, validate_browser_url
+import server
 
 
 class BrowserManagerTests(unittest.TestCase):
@@ -82,6 +83,119 @@ window.addEventListener('DOMContentLoaded', () => {
                 self.assertIn("updated", clicked)
                 closed = manager.close(session_id)
                 self.assertIn("closed", closed)
+
+                class ChatHandler(http.server.BaseHTTPRequestHandler):
+                    def do_GET(self):  # noqa: N802 - stdlib HTTP server contract
+                        if self.path == "/":
+                            body = server.CHAT_HTML.encode("utf-8")
+                            content_type = "text/html; charset=utf-8"
+                        elif self.path == "/api/cost":
+                            body = b'{"summary":"initial-cost"}'
+                            content_type = "application/json"
+                        else:
+                            self.send_error(404)
+                            return
+                        self.send_response(200)
+                        self.send_header("Content-Type", content_type)
+                        self.send_header("Content-Length", str(len(body)))
+                        self.end_headers()
+                        self.wfile.write(body)
+
+                    def log_message(self, *_args):
+                        return
+
+                chat_httpd = http.server.ThreadingHTTPServer(("127.0.0.1", 0), ChatHandler)
+                chat_thread = threading.Thread(target=chat_httpd.serve_forever, daemon=True)
+                chat_thread.start()
+                playwright = None
+                browser = None
+                try:
+                    from playwright.sync_api import sync_playwright
+
+                    playwright = sync_playwright().start()
+                    browser = playwright.chromium.launch(headless=True)
+                    page = browser.new_page()
+                    page.add_init_script(r"""
+const originalFetch = window.fetch.bind(window);
+let streamCall = 0;
+window.fetch = async (input, init) => {
+  const url = typeof input === 'string' ? input : input.url;
+  if (url.endsWith('/api/cost')) {
+    return new Response(JSON.stringify({summary: 'initial-cost'}), {
+      status: 200, headers: {'Content-Type': 'application/json'}
+    });
+  }
+  if (!url.endsWith('/api/chat/stream')) return originalFetch(input, init);
+  streamCall += 1;
+  const frames = streamCall === 1 ? [
+    'data: {"chunk":"Hello "}\n\n',
+    'data: {"chunk":"世界"}\n\n',
+    'data: {"cost":"Cost: split-stream"}\n\n',
+    'data: [DONE]\n\n'
+  ] : ['data: {"error":"mock provider failure"}\n\n'];
+  const bytes = new TextEncoder().encode(frames.join(''));
+  return new Response(new ReadableStream({
+    start(controller) {
+      let offset = 0;
+      let part = 0;
+      const sizes = [1, 4, 2, 7, 3, 5];
+      function enqueueNext() {
+        if (offset >= bytes.length) {
+          controller.close();
+          return;
+        }
+        const end = Math.min(bytes.length, offset + sizes[part % sizes.length]);
+        controller.enqueue(bytes.slice(offset, end));
+        offset = end;
+        part += 1;
+        setTimeout(enqueueNext, 20);
+      }
+      enqueueNext();
+    }
+  }), {status: 200, headers: {'Content-Type': 'text/event-stream'}});
+};
+""")
+                    page.goto(
+                        f"http://127.0.0.1:{chat_httpd.server_port}/",
+                        wait_until="domcontentloaded",
+                    )
+                    page.fill("#user-input", "split boundary")
+                    page.click("#send-btn")
+                    page.wait_for_function(
+                        "document.querySelector('.msg.assistant .content').textContent.includes('Hello')"
+                    )
+                    self.assertEqual(page.locator("#status").text_content(), "Thinking...")
+                    page.wait_for_function(
+                        "document.getElementById('status').textContent === 'Ready'"
+                    )
+                    assistant = page.locator(".msg.assistant .content").nth(0)
+                    self.assertEqual(assistant.text_content(), "Hello 世界")
+                    self.assertEqual(
+                        page.locator("#cost-display").text_content(), "Cost: split-stream"
+                    )
+                    self.assertNotIn("parse error", assistant.text_content().lower())
+
+                    page.fill("#user-input", "error boundary")
+                    page.click("#send-btn")
+                    page.wait_for_function(
+                        "document.querySelectorAll('.msg.assistant .content')[1].textContent.includes('mock provider failure')"
+                    )
+                    page.wait_for_function(
+                        "document.getElementById('status').textContent === 'Error'"
+                    )
+                    self.assertEqual(page.locator("#status").text_content(), "Error")
+                    self.assertEqual(
+                        page.locator(".msg.assistant .content").nth(1).text_content(),
+                        "Error: mock provider failure",
+                    )
+                finally:
+                    if browser is not None:
+                        browser.close()
+                    if playwright is not None:
+                        playwright.stop()
+                    chat_httpd.shutdown()
+                    chat_httpd.server_close()
+                    chat_thread.join(timeout=5)
         finally:
             if manager is not None:
                 manager.close_all()


### PR DESCRIPTION
Fixes #67\n\nAdds a cross-read SSE buffer for the embedded chat UI, streams UTF-8 decoding correctly, flushes decoder and residual events, and distinguishes complete DONE streams from error/incomplete streams. Cost, error, Unicode, and chunk data are handled without silent parse loss. Extends the real Chromium smoke flow with irregular byte-boundary ReadableStream fixtures and verifies content-before-Ready, cost, DONE, and error behavior.\n\nValidation: make check; make lint; make test (130); make docs-check; make shell-check; git diff --check; real Chromium SSE smoke.