### PR TITLE
docs: document release validation and publishing

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -644,10 +644,16 @@ make push
 ### CI/CD
 
 GitHub Actions がプッシュと PR ごとに自動実行：
+
 - Python 3.12 および 3.13 での構文チェック
 - 実行時レジストリから生成したツール一覧とドキュメントの整合性検証
 - プロバイダーインポートチェック
+- クリーンな wheel インストールと無関係なディレクトリからの CLI スモークテスト
+- Windows PowerShell インストーラーの構文とヘルプ経路のチェック
 - Docker ビルドとコンテナ置換後の復元スモークテスト
+
+`v*` タグをプッシュすると、sdist/wheel をビルドして検証し、設定済みの
+`pypi` 環境ゲート後に GitHub Trusted Publishing で PyPI へ公開します。
 
 ### pip パッケージ
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -642,10 +642,16 @@ make push
 ### CI/CD
 
 GitHub Actions가 모든 푸시와 PR에서 자동 실행:
+
 - Python 3.12 및 3.13에서 구문 검사
 - 실제 런타임 레지스트리에서 생성한 도구 목록과 문서 일관성 검사
 - 제공자 임포트 확인
+- 깨끗한 wheel 설치 및 무관한 디렉터리에서 CLI를 실행하는 스모크 테스트
+- Windows PowerShell 설치 프로그램 구문 및 도움말 경로 확인
 - Docker 빌드 및 컨테이너 교체 복구 스모크 테스트
+
+`v*` 태그를 푸시하면 sdist/wheel을 빌드하고 검증한 뒤, 설정된 `pypi`
+환경 게이트를 통과하면 GitHub Trusted Publishing으로 PyPI에 게시합니다.
 
 ### pip 패키지
 

--- a/README.md
+++ b/README.md
@@ -898,10 +898,17 @@ make push
 ### CI/CD
 
 GitHub Actions automatically runs on every push and PR:
+
 - Syntax check across Python 3.12 and 3.13
 - Generated tool inventory and documentation consistency validation
 - Provider import check
+- Clean wheel installation and unrelated-directory CLI smoke test
+- Windows PowerShell installer syntax/help check
 - Docker build and replace-container recovery smoke test
+
+A `v*` tag additionally builds and validates sdist/wheel distributions, then
+publishes them to PyPI through GitHub Trusted Publishing after the configured
+`pypi` environment gate.
 
 ### pip package
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -654,10 +654,16 @@ make push
 ### CI/CD
 
 GitHub Actions 在每次推送和 PR 时自动运行：
+
 - Python 3.12 和 3.13 语法检查
 - 从真实注册表生成的工具清单和文档一致性检查
 - 服务商导入检查
+- 干净 wheel 安装及从无关目录启动 CLI 的 smoke test
+- Windows PowerShell 安装器语法和帮助路径检查
 - Docker 构建和替换容器恢复 smoke test
+
+推送 `v*` 版本标签时，还会构建并验证 sdist/wheel，并在配置好的
+`pypi` 环境门禁后通过 GitHub Trusted Publishing 发布到 PyPI。
 
 ### pip 包
 


### PR DESCRIPTION
Documents the expanded CI coverage for wheel installation, Windows installer validation, Docker persistence, and the tag-triggered PyPI Trusted Publishing workflow across all README variants.