### PR TITLE
fix: make full development setup reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,22 @@ on:
     branches: [main]
 
 jobs:
+  core-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install core package and run lightweight tests
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+        make test-core PYTHON=python
+
   lint-and-test:
     runs-on: ubuntu-latest
     strategy:
@@ -21,19 +37,17 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
+    - name: Install full development dependencies
       run: |
         sudo apt-get update
         sudo apt-get install --no-install-recommends -y zsh
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install fastapi uvicorn
+        pip install -e '.[all]'
 
-    - name: Install package and run unit tests
+    - name: Install Chromium and run the full test suite
       run: |
-        pip install -e '.[browser]'
         python -m playwright install --with-deps chromium
-        python -m unittest discover -s tests -p 'test_*.py' -v
+        make test PYTHON=python
 
     - name: Syntax check
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
       with:
         python-version: "3.12"
 
-    - name: Install core package and run lightweight tests
+    - name: Install non-browser package and run lightweight tests
       run: |
         python -m pip install --upgrade pip
-        pip install -e .
+        pip install -e '.[web]'
         make test-core PYTHON=python
 
   lint-and-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,10 @@ jobs:
       with:
         python-version: "3.12"
 
-    - name: Install non-browser package and run lightweight tests
+    - name: Provision the non-browser development path and run lightweight tests
       run: |
-        python -m pip install --upgrade pip
-        pip install -e '.[web]'
-        make test-core PYTHON=python
+        make install-core PYTHON=python
+        make test-core
 
   lint-and-test:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ install-core:
 	@echo "Creating virtual environment with $(PYTHON)..."
 	@command -v $(PYTHON) >/dev/null 2>&1 || { echo "Error: $(PYTHON) not found. Install Python 3.12 first."; exit 1; }
 	$(PYTHON) -m venv venv
-	./venv/bin/python -m pip install --upgrade pip && ./venv/bin/python -m pip install -e .
+	./venv/bin/python -m pip install --upgrade pip && ./venv/bin/python -m pip install -e '.[web]'
 	@echo ""
 	@echo "OpenKyrozen core development environment installed."
 
@@ -65,7 +65,7 @@ lint:
 test:
 	KYROZEN_BROWSER_TESTS=1 $(VENV_PYTHON) -m unittest discover -s tests -p 'test_*.py' -v
 
-# Fast unit path for contributors and CI jobs that intentionally omit browser binaries.
+# Fast non-browser path for contributors and CI jobs that intentionally omit browser binaries.
 test-core:
 	KYROZEN_BROWSER_TESTS=0 $(VENV_PYTHON) -m unittest discover -s tests -p 'test_*.py' -v
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .PHONY: install install-core run clean lint test test-core check docs-check shell-check benchmark wheel-smoke docker-smoke git-status git-diff git-log web
 
+# Tests parse the benchmark target's stdout as JSON; do not inject GNU make's
+# recursive directory banners into that machine-readable output.
+MAKEFLAGS += --no-print-directory
+
 # Prefer the known-stable Python 3.12, but use the active supported Python
 # 3.13 on clean runners that do not provide 3.12. Python 3.14 remains
 # intentionally out of scope because of the OpenAI SDK import deadlock.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install run clean lint test check docs-check shell-check benchmark wheel-smoke docker-smoke git-status git-diff git-log web
+.PHONY: install install-core run clean lint test test-core check docs-check shell-check benchmark wheel-smoke docker-smoke git-status git-diff git-log web
 
 # Prefer the known-stable Python 3.12, but use the active supported Python
 # 3.13 on clean runners that do not provide 3.12. Python 3.14 remains
@@ -13,13 +13,21 @@ ifeq ($(OS),Windows_NT)
 $(error This Makefile is for macOS/Linux/WSL. On native Windows, use: setup.bat, run.bat)
 endif
 
-install:
+install-core:
 	@echo "Creating virtual environment with $(PYTHON)..."
 	@command -v $(PYTHON) >/dev/null 2>&1 || { echo "Error: $(PYTHON) not found. Install Python 3.12 first."; exit 1; }
 	$(PYTHON) -m venv venv
-	./venv/bin/python -m pip install --upgrade pip && ./venv/bin/python -m pip install -r requirements.txt
+	./venv/bin/python -m pip install --upgrade pip && ./venv/bin/python -m pip install -e .
 	@echo ""
-	@echo "OpenKyrozen installed. Run 'make run' for project mode or 'kyrozen' for the global workspace."
+	@echo "OpenKyrozen core development environment installed."
+
+# The documented development path includes every optional integration and the
+# Chromium binary required by the browser integration test.
+install: install-core
+	./venv/bin/python -m pip install -e '.[all]'
+	./venv/bin/python -m playwright install chromium
+	@echo ""
+	@echo "OpenKyrozen full development environment installed. Run 'make test' or 'make run'."
 
 run:
 	@command -v $(PYTHON) >/dev/null 2>&1 || { echo "Error: venv requires $(PYTHON). Run 'make install' with $(PYTHON) installed."; exit 1; }
@@ -55,7 +63,11 @@ lint:
 
 # Unit tests
 test:
-	$(VENV_PYTHON) -m unittest discover -s tests -p 'test_*.py' -v
+	KYROZEN_BROWSER_TESTS=1 $(VENV_PYTHON) -m unittest discover -s tests -p 'test_*.py' -v
+
+# Fast unit path for contributors and CI jobs that intentionally omit browser binaries.
+test-core:
+	KYROZEN_BROWSER_TESTS=0 $(VENV_PYTHON) -m unittest discover -s tests -p 'test_*.py' -v
 
 benchmark:
 	@$(VENV_PYTHON) -c "import openai, requests, rich, yaml" >/dev/null 2>&1 || { echo "Error: benchmark dependencies are missing. Run 'make install' first."; exit 1; }

--- a/README.ja.md
+++ b/README.ja.md
@@ -118,7 +118,7 @@ run.bat
 ```
 
 これらのコマンドは明示的にプロジェクトモード（`--project .`）で動作し、リポジトリ開発専用です。
-`make install` は完全な `.[all]` 開発依存関係と Chromium を導入するため、`make test` でブラウザー統合フローも実行します。軽量なコア専用パスには `make install-core` と `make test-core` を使用してください。
+`make install` は完全な `.[all]` 開発依存関係と Chromium を導入するため、`make test` でブラウザー統合フローも実行します。軽量な非ブラウザーパスには `make install-core` と `make test-core` を使用してください。
 
 ### PyPI からのパッケージインストール
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -109,6 +109,7 @@ cd OpenKyrozen
 
 # macOS / Linux
 make install
+make test
 make run
 
 # Windows
@@ -117,6 +118,7 @@ run.bat
 ```
 
 これらのコマンドは明示的にプロジェクトモード（`--project .`）で動作し、リポジトリ開発専用です。
+`make install` は完全な `.[all]` 開発依存関係と Chromium を導入するため、`make test` でブラウザー統合フローも実行します。軽量なコア専用パスには `make install-core` と `make test-core` を使用してください。
 
 ### PyPI からのパッケージインストール
 
@@ -665,7 +667,7 @@ pip install 'openkyrozen[web]'
 # ローカルチェックアウトのみ（開発）
 pip install .                   # コア + CLI
 pip install '.[web]'            # + Web UI
-pip install '.[all]'            # + Claude + Gemini + Web
+pip install '.[all]'            # + Claude + Gemini + Web + Playwright
 ```
 
 ---

--- a/README.ko.md
+++ b/README.ko.md
@@ -109,6 +109,7 @@ cd OpenKyrozen
 
 # macOS / Linux
 make install
+make test
 make run
 
 # Windows
@@ -117,6 +118,7 @@ run.bat
 ```
 
 이 명령들은 프로젝트 모드(`--project .`)로 실행되며 저장소 개발 전용입니다.
+`make install`은 전체 `.[all]` 개발 의존성과 Chromium을 설치하므로 `make test`에서 브라우저 통합 흐름도 실행합니다. 가벼운 코어 전용 경로에는 `make install-core`와 `make test-core`를 사용하세요.
 
 ### PyPI 패키지 설치
 
@@ -663,7 +665,7 @@ pip install 'openkyrozen[web]'
 # 로컬 체크아웃 전용 (개발)
 pip install .                   # 코어 + CLI
 pip install '.[web]'            # + Web UI
-pip install '.[all]'            # + Claude + Gemini + Web
+pip install '.[all]'            # + Claude + Gemini + Web + Playwright
 ```
 
 ---

--- a/README.ko.md
+++ b/README.ko.md
@@ -118,7 +118,7 @@ run.bat
 ```
 
 이 명령들은 프로젝트 모드(`--project .`)로 실행되며 저장소 개발 전용입니다.
-`make install`은 전체 `.[all]` 개발 의존성과 Chromium을 설치하므로 `make test`에서 브라우저 통합 흐름도 실행합니다. 가벼운 코어 전용 경로에는 `make install-core`와 `make test-core`를 사용하세요.
+`make install`은 전체 `.[all]` 개발 의존성과 Chromium을 설치하므로 `make test`에서 브라우저 통합 흐름도 실행합니다. 가벼운 비브라우저 경로에는 `make install-core`와 `make test-core`를 사용하세요.
 
 ### PyPI 패키지 설치
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ cd OpenKyrozen
 
 # macOS / Linux
 make install
+make test
 make run
 
 # Windows
@@ -118,6 +119,7 @@ run.bat
 ```
 
 These commands intentionally run in project mode (`--project .`) and are for repository development.
+`make install` installs the full `.[all]` development set and Chromium, so `make test` also runs the browser integration flow. For a lightweight core-only path, use `make install-core` followed by `make test-core`.
 
 ### Package installation from PyPI
 
@@ -920,7 +922,7 @@ pip install 'openkyrozen[web]'  # existing supported environment
 # Local checkout only (development)
 pip install .
 pip install '.[web]'
-pip install '.[all]'
+pip install '.[all]'            # + Claude + Gemini + Web + Playwright
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ run.bat
 ```
 
 These commands intentionally run in project mode (`--project .`) and are for repository development.
-`make install` installs the full `.[all]` development set and Chromium, so `make test` also runs the browser integration flow. For a lightweight core-only path, use `make install-core` followed by `make test-core`.
+`make install` installs the full `.[all]` development set and Chromium, so `make test` also runs the browser integration flow. For a lightweight non-browser path, use `make install-core` followed by `make test-core`.
 
 ### Package installation from PyPI
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -118,7 +118,7 @@ run.bat
 ```
 
 这些命令会显式使用项目模式（`--project .`），仅用于仓库开发。
-`make install` 会安装完整的 `.[all]` 开发依赖和 Chromium，因此 `make test` 也会运行浏览器集成流程。若只需轻量核心路径，请使用 `make install-core` 和 `make test-core`。
+`make install` 会安装完整的 `.[all]` 开发依赖和 Chromium，因此 `make test` 也会运行浏览器集成流程。若只需轻量的非浏览器路径，请使用 `make install-core` 和 `make test-core`。
 
 ### 从 PyPI 安装
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -109,6 +109,7 @@ cd OpenKyrozen
 
 # macOS / Linux
 make install
+make test
 make run
 
 # Windows
@@ -117,6 +118,7 @@ run.bat
 ```
 
 这些命令会显式使用项目模式（`--project .`），仅用于仓库开发。
+`make install` 会安装完整的 `.[all]` 开发依赖和 Chromium，因此 `make test` 也会运行浏览器集成流程。若只需轻量核心路径，请使用 `make install-core` 和 `make test-core`。
 
 ### 从 PyPI 安装
 
@@ -675,7 +677,7 @@ pip install 'openkyrozen[web]'
 # 仅限本地源码检出（开发）
 pip install .                   # 核心 + CLI
 pip install '.[web]'            # + Web UI
-pip install '.[all]'            # + Claude + Gemini + Web
+pip install '.[all]'            # + Claude + Gemini + Web + Playwright
 ```
 
 ---

--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **146 unittest cases**.
+Current repository test count at this snapshot: **147 unittest cases**.
 
 ## Verified surface
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ web = ["fastapi", "uvicorn"]
 claude = ["anthropic>=0.30.0"]
 gemini = ["google-generativeai>=0.8.0"]
 browser = ["playwright>=1.40"]
-all = ["fastapi", "uvicorn", "anthropic>=0.30.0", "google-generativeai>=0.8.0"]
+all = ["fastapi", "uvicorn", "anthropic>=0.30.0", "google-generativeai>=0.8.0", "playwright>=1.40"]
 
 [project.scripts]
 kyrozen = "main:main"

--- a/tests/test_browser_manager.py
+++ b/tests/test_browser_manager.py
@@ -34,6 +34,10 @@ class BrowserManagerTests(unittest.TestCase):
                 result = manager.open("https://example.com")
             self.assertIn("playwright", result.lower())
 
+    @unittest.skipUnless(
+        os.environ.get("KYROZEN_BROWSER_TESTS") == "1",
+        "browser integration requires `make install` (Playwright and Chromium)",
+    )
     def test_real_open_snapshot_click_and_close_flow(self):
         class Handler(http.server.BaseHTTPRequestHandler):
             def do_GET(self):  # noqa: N802 - required by BaseHTTPRequestHandler

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -34,6 +34,7 @@ class DistributionTests(unittest.TestCase):
         self.assertIn("pip install -e '.[all]'", makefile)
         self.assertIn("python -m playwright install chromium", makefile)
         self.assertIn("test-core:", makefile)
+        self.assertIn("MAKEFLAGS += --no-print-directory", makefile)
 
         workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
         self.assertIn("pip install -e '.[all]'", workflow)

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -23,6 +23,22 @@ class DistributionTests(unittest.TestCase):
         self.assertEqual(project["scripts"]["kyrozen-web"], "server:main_entry")
         self.assertIn("workspace_context", document["tool"]["setuptools"]["py-modules"])
 
+    def test_full_development_setup_includes_browser_and_core_test_path(self):
+        with (ROOT / "pyproject.toml").open("rb") as handle:
+            document = tomllib.load(handle)
+        self.assertIn("playwright>=1.40", document["project"]["optional-dependencies"]["all"])
+
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        self.assertIn("install: install-core", makefile)
+        self.assertIn("pip install -e '.[all]'", makefile)
+        self.assertIn("python -m playwright install chromium", makefile)
+        self.assertIn("test-core:", makefile)
+
+        workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        self.assertIn("pip install -e '.[all]'", workflow)
+        self.assertIn("make test PYTHON=python", workflow)
+        self.assertIn("make test-core PYTHON=python", workflow)
+
     def test_posix_installer_has_valid_syntax_and_idempotent_user_path_logic(self):
         installer = ROOT / "install.sh"
         result = subprocess.run(

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -36,10 +36,10 @@ class DistributionTests(unittest.TestCase):
         self.assertIn("test-core:", makefile)
 
         workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-        self.assertIn("pip install -e '.[web]'", workflow)
         self.assertIn("pip install -e '.[all]'", workflow)
         self.assertIn("make test PYTHON=python", workflow)
-        self.assertIn("make test-core PYTHON=python", workflow)
+        self.assertIn("make install-core PYTHON=python", workflow)
+        self.assertIn("make test-core", workflow)
 
     def test_posix_installer_has_valid_syntax_and_idempotent_user_path_logic(self):
         installer = ROOT / "install.sh"

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -30,11 +30,13 @@ class DistributionTests(unittest.TestCase):
 
         makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
         self.assertIn("install: install-core", makefile)
+        self.assertIn("pip install -e '.[web]'", makefile)
         self.assertIn("pip install -e '.[all]'", makefile)
         self.assertIn("python -m playwright install chromium", makefile)
         self.assertIn("test-core:", makefile)
 
         workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        self.assertIn("pip install -e '.[web]'", workflow)
         self.assertIn("pip install -e '.[all]'", workflow)
         self.assertIn("make test PYTHON=python", workflow)
         self.assertIn("make test-core PYTHON=python", workflow)

--- a/tests/test_learning_benchmark.py
+++ b/tests/test_learning_benchmark.py
@@ -49,10 +49,7 @@ class LearningBenchmarkTests(unittest.TestCase):
                 capture_output=True, text=True, timeout=120,
         )
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        try:
-            report = json.loads(result.stdout)
-        except json.JSONDecodeError as exc:
-            self.fail(f"benchmark did not emit JSON: stdout={result.stdout!r}; stderr={result.stderr!r}; {exc}")
+        report = json.loads(result.stdout)
         self.assertEqual(report["protocol"], "openkyrozen-learning-benchmark-v1")
         self.assertEqual(report["case_order"], [
             "speaker-belief-isolation", "speaker-update", "private-leakage",

--- a/tests/test_learning_benchmark.py
+++ b/tests/test_learning_benchmark.py
@@ -47,8 +47,9 @@ class LearningBenchmarkTests(unittest.TestCase):
             result = subprocess.run(
                 ["make", "benchmark"], cwd=repository, env=env,
                 capture_output=True, text=True, timeout=120,
-            )
+        )
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(result.stdout.strip(), result.stderr)
         report = json.loads(result.stdout)
         self.assertEqual(report["protocol"], "openkyrozen-learning-benchmark-v1")
         self.assertEqual(report["case_order"], [

--- a/tests/test_learning_benchmark.py
+++ b/tests/test_learning_benchmark.py
@@ -49,8 +49,10 @@ class LearningBenchmarkTests(unittest.TestCase):
                 capture_output=True, text=True, timeout=120,
         )
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        self.assertTrue(result.stdout.strip(), result.stderr)
-        report = json.loads(result.stdout)
+        try:
+            report = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            self.fail(f"benchmark did not emit JSON: stdout={result.stdout!r}; stderr={result.stderr!r}; {exc}")
         self.assertEqual(report["protocol"], "openkyrozen-learning-benchmark-v1")
         self.assertEqual(report["case_order"], [
             "speaker-belief-isolation", "speaker-update", "private-leakage",


### PR DESCRIPTION
Fixes #75

## Summary
- include Playwright in the `all` extra
- provision Chromium in the documented full development target
- keep `install-core` / `test-core` for lightweight environments
- align CI and browser-test gating

## Validation
- clean disposable checkout: `make install` then `make test` (147 tests)
- `make test-core`
- `make check`
- `make docs-check`
- `make shell-check`
- `make lint`
- `git diff --check`