### PR TITLE
fix: persist durable command failures

### DIFF
--- a/docs/tool-inventory.md
+++ b/docs/tool-inventory.md
@@ -21,7 +21,7 @@ Run `make docs-check` after changing a tool, endpoint, or MCP contract.
 | `browser_snapshot` | `browser` | Read the current page text. Args: browser session ID. | `session_id`: string; required: `session_id` |
 | `browser_type` | `browser` | Fill a selector. Args format: session_id\|CSS selector\|text. | `session_id`: string, `selector`: string, `text`: string; required: `session_id`, `selector`, `text` |
 | `check_stored_data` | `read` | Return a categorized summary of stored memories. | `args`: string |
-| `execute_terminal_command` | `shell` | Execute a terminal command. This is an alias for run_cmd. | `command`: string; required: `command` |
+| `execute_terminal_command` | `shell` | Execute a shell command and retain its machine-readable outcome. | `command`: string; required: `command` |
 | `find_files` | `read` | Find files matching a pattern. Args format: "pattern" or "pattern\|directory". | `pattern`: string, `directory`: string; required: `pattern` |
 | `git_add` | `git` | Stage files for commit. Args format: "file1 file2" or "." (stage all). | `args`: string |
 | `git_branch` | `dynamic` | List or manage git branches. Args format: "" (list all), "branch_name" (create), | `args`: string |
@@ -41,7 +41,7 @@ Run `make docs-check` after changing a tool, endpoint, or MCP contract.
 | `list_tree` | `read` | Recursively list the directory tree of the given path. Args format: "path" (default "."). | `path`: string |
 | `read_file` | `read` | Read content from a file. Args format: "path". | `path`: string; required: `path` |
 | `read_webpage` | `network` | Fetch the content of a web page and return its plain‑text body. | `url`: string; required: `url` |
-| `run_cmd` | `shell` | Execute a shell command. Args: the full command string. | `command`: string; required: `command` |
+| `run_cmd` | `shell` | Execute a shell command and retain its machine-readable outcome. | `command`: string; required: `command` |
 | `search_memory` | `read` | Search stored memories for facts relevant to the query. Args: "query" | `args`: string |
 | `search_web` | `network` | Search the internet for real-time information. | `query`: string; required: `query` |
 | `write_file` | `write` | Write content to a file. Args format: "path\|content". | `path`: string, `content`: string; required: `path`, `content` |

--- a/main.py
+++ b/main.py
@@ -103,7 +103,7 @@ from dynamic_tools import SAFE_BUILTINS, validate_tool_source
 from plugin_runtime import get_plugin_runtime
 from workspace_context import LaunchContext, resolve_launch_context, source_scope_id
 from tools import (AVAILABLE_TOOLS, set_workspace_root as _set_tools_workspace_root,
-                   resolve_capabilities, tool_capability)
+                   CommandResult, resolve_capabilities, tool_capability)
 from providers import (
     ProviderConfig, LLMProvider, get_provider, detect_provider,
     save_provider_config, PROVIDER_DEFAULT_MODELS, PROVIDER_ENV_VARS,
@@ -2994,7 +2994,10 @@ def _notify_tool_execute(action: str, args: Any, result: Any) -> None:
         pass
 
 
-def _run_tool(action: str, args: str) -> str:
+def _run_tool(action: str, args: str, *, return_success: bool = False) -> str | tuple[str, bool]:
+    def finish(result: str, success: bool = False) -> str | tuple[str, bool]:
+        return (result, success) if return_success else result
+
     # Map aliases
     action = TOOL_ALIASES.get(action, action)
     # Handle dict arguments for tools that expect a simple string
@@ -3028,7 +3031,7 @@ def _run_tool(action: str, args: str) -> str:
     if not fn:
         result = f"Error: unknown tool '{action}'"
         _notify_tool_execute(action, args, result)
-        return result
+        return finish(result)
     required_capability = tool_capability(action)
     try:
         if required_capability not in effective_capabilities(load_agent_config(_get_workspace_root())):
@@ -3037,33 +3040,37 @@ def _run_tool(action: str, args: str) -> str:
                 "which is outside the configured agent capability bound"
             )
             _notify_tool_execute(action, args, result)
-            return result
+            return finish(result)
     except AgentConfigError as exc:
         result = f"Error: invalid agent configuration: {exc}"
         _notify_tool_execute(action, args, result)
-        return result
+        return finish(result)
     if not _execution_capability_token.allows(required_capability):
         result = f"Error: tool '{action}' requires capability '{required_capability}'"
         _notify_tool_execute(action, args, result)
-        return result
+        return finish(result)
     if not _confirm_tool_action(action, str(args)):
         result = (
             f"Error: {action} requires confirmation. "
             "Approve it interactively or set KYROZEN_APPROVAL_MODE=never for an explicitly automated CLI."
         )
         _notify_tool_execute(action, args, result)
-        return result
+        return finish(result)
     start = time.time()
     try:
-        result = str(fn(args))
+        tool_result = fn(args)
+        result = str(tool_result)
+        success = tool_result.success if isinstance(tool_result, CommandResult) else not _is_tool_error(result)
     except KeyboardInterrupt:
         result = "Tool execution interrupted by user (Ctrl+C)."
+        success = False
     except Exception as e:
         result = f"Error: {e}"
+        success = False
     elapsed = time.time() - start
     _track_tool_performance(action, result, elapsed)
     _notify_tool_execute(action, args, result)
-    return result
+    return finish(result, success)
 
 
 def _execute_durable_task(task: dict[str, Any]) -> dict[str, Any]:
@@ -3077,8 +3084,9 @@ def _execute_durable_task(task: dict[str, Any]) -> dict[str, Any]:
                 "result": "No executable action stored; create the task with action and string args."}
     if not isinstance(args, str):
         return {"success": False, "action": action, "result": "Task args must be a plain string."}
-    result = str(_run_tool(action, args))[:2000]
-    return {"success": not _is_tool_error(result), "action": action, "args": args, "result": result,
+    result, success = _run_tool(action, args, return_success=True)
+    result = result[:2000]
+    return {"success": success, "action": action, "args": args, "result": result,
             "acceptance": str(checkpoint.get("acceptance") or "durable task action completed")}
 
 

--- a/server.py
+++ b/server.py
@@ -169,9 +169,10 @@ def _execute_durable_task(task: dict[str, Any]) -> dict[str, Any]:
     _agent._execution_capability_token = issue_capability_token(
         "surface:web:durable-task", _server_capabilities("web"), ttl_seconds=300,
     )
-    result = str(_agent._run_tool(action, args))[:2000]
+    result, success = _agent._run_tool(action, args, return_success=True)
+    result = result[:2000]
     return {
-        "success": not result.lower().startswith("error:"), "action": action, "args": args,
+        "success": success, "action": action, "args": args,
         "result": result,
         "acceptance": str(checkpoint.get("acceptance") or "durable task action completed"),
     }

--- a/tests/test_durable_tasks_gateway.py
+++ b/tests/test_durable_tasks_gateway.py
@@ -98,6 +98,17 @@ class DurableTaskGatewayTests(unittest.TestCase):
                 checkpoint={"action": "write_file", "args": "recovered.txt|after restart"},
             )
             recovery_manager.set_status(recovery_index, "running")
+            command_manager = TaskManager(
+                store, user_id="local", workspace_id="default", session_id="restart-command-session"
+            )
+            command_index = command_manager.add_task(
+                "fail a recovered command task",
+                checkpoint={
+                    "action": "execute_terminal_command",
+                    "args": f'{sys.executable} -c "import sys; sys.exit(7)"',
+                },
+            )
+            command_manager.set_status(command_index, "running")
             failed_manager = TaskManager(
                 store, user_id="local", workspace_id="default", session_id="resume-session"
             )
@@ -116,6 +127,21 @@ class DurableTaskGatewayTests(unittest.TestCase):
                     time.sleep(0.1)
                 self.assertEqual(recovered["tasks"][0]["status"], "succeeded")
                 self.assertEqual((workspace / "recovered.txt").read_text(encoding="utf-8"), "after restart")
+
+                deadline = time.monotonic() + 10
+                recovered_command = self._request(
+                    base_url, "/api/v2/tasks?session_id=restart-command-session"
+                )
+                while time.monotonic() < deadline:
+                    recovered_command = self._request(
+                        base_url, "/api/v2/tasks?session_id=restart-command-session"
+                    )
+                    if recovered_command["tasks"][0]["status"] == "failed":
+                        break
+                    time.sleep(0.1)
+                self.assertEqual(recovered_command["tasks"][0]["status"], "failed")
+                self.assertTrue(recovered_command["tasks"][0]["evidence"])
+                self.assertFalse(recovered_command["tasks"][0]["evidence"][-1]["success"])
 
                 created = self._request(
                     base_url,
@@ -143,6 +169,28 @@ class DurableTaskGatewayTests(unittest.TestCase):
                     (workspace / "task-runtime.txt").read_text(encoding="utf-8"),
                     "created by durable worker",
                 )
+
+                succeeded_command = self._request(
+                    base_url,
+                    "/api/v2/tasks",
+                    method="POST",
+                    body={
+                        "description": "complete a zero-exit command task",
+                        "session_id": "task-command-success",
+                        "action": "run_cmd",
+                        "args": f'{sys.executable} -c "print(\'durable success\')"',
+                    },
+                )["task"]
+                deadline = time.monotonic() + 10
+                while time.monotonic() < deadline:
+                    succeeded_command = self._request(
+                        base_url, "/api/v2/tasks?session_id=task-command-success"
+                    )["tasks"][0]
+                    if succeeded_command["status"] == "succeeded":
+                        break
+                    time.sleep(0.1)
+                self.assertEqual(succeeded_command["status"], "succeeded")
+                self.assertTrue(succeeded_command["evidence"][-1]["success"])
 
                 before_resume = self._request(base_url, "/api/v2/tasks?session_id=resume-session")
                 self.assertEqual(before_resume["tasks"][0]["status"], "failed")

--- a/tools.py
+++ b/tools.py
@@ -14,6 +14,7 @@ import http.client
 import ipaddress
 import socket
 import ssl
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin, urlsplit
@@ -137,16 +138,30 @@ def read_file(args: str) -> str:
         return f"Error reading file: {e}"
 
 
-def run_cmd(args: str) -> str:
+@dataclass(frozen=True)
+class CommandResult:
+    """The durable outcome of one shell command, separate from its display text."""
+
+    output: str
+    success: bool
+    exit_code: int | None = None
+    failure: str | None = None
+
+    def __str__(self) -> str:
+        return self.output
+
+
+def run_command(args: str) -> CommandResult:
     """
-    Execute a shell command. Args: the full command string.
-    Blocks dangerous operations (e.g. rm -rf).
+    Execute a shell command and retain its machine-readable outcome.
     """
     cmd = args.strip()
     if not cmd:
-        return "Error: run_cmd requires a command"
+        return CommandResult("Error: run_cmd requires a command", False, failure="invalid_arguments")
     if _is_dangerous(cmd):
-        return "Error: command blocked for safety (e.g. rm -rf or similar)."
+        return CommandResult(
+            "Error: command blocked for safety (e.g. rm -rf or similar).", False, failure="denied"
+        )
     try:
         result = subprocess.run(
             cmd,
@@ -160,12 +175,20 @@ def run_cmd(args: str) -> str:
         out = result.stdout or ""
         err = result.stderr or ""
         if result.returncode != 0:
-            return f"Exit code {result.returncode}\nstdout:\n{out}\nstderr:\n{err}".strip()
-        return out.strip() or "(no output)"
+            return CommandResult(
+                f"Exit code {result.returncode}\nstdout:\n{out}\nstderr:\n{err}".strip(),
+                False, result.returncode, "nonzero_exit",
+            )
+        return CommandResult(out.strip() or "(no output)", True, result.returncode)
     except subprocess.TimeoutExpired:
-        return "Error: command timed out after 60s"
+        return CommandResult("Error: command timed out after 60s", False, failure="timeout")
     except Exception as e:
-        return f"Error running command: {e}"
+        return CommandResult(f"Error running command: {e}", False, failure="execution_error")
+
+
+def run_cmd(args: str) -> str:
+    """Execute a shell command. Args: the full command string."""
+    return str(run_command(args))
 
 
 def search_web(args: str) -> str:
@@ -692,7 +715,7 @@ def execute_terminal_command(args: str) -> str:
     """
     Execute a terminal command. This is an alias for run_cmd.
     """
-    return run_cmd(args)
+    return str(run_command(args))
 
 
 def analyze_remote_repo(args: str) -> str:
@@ -976,7 +999,7 @@ def browser_close(args: str) -> str:
 AVAILABLE_TOOLS: dict[str, Any] = {
     "write_file": write_file,
     "read_file": read_file,
-    "run_cmd": run_cmd,
+    "run_cmd": run_command,
     "search_web": search_web,
     "find_files": find_files,
     "list_dir": list_dir,
@@ -994,7 +1017,7 @@ AVAILABLE_TOOLS: dict[str, Any] = {
     "git_reset": git_reset,
     "git_show": git_show,
     "git_remote": git_remote,
-    "execute_terminal_command": execute_terminal_command,
+    "execute_terminal_command": run_command,
     "analyze_remote_repo": analyze_remote_repo,
     "list_tree": list_tree,
     "read_webpage": read_webpage,


### PR DESCRIPTION
Fixes #74

## Summary
- preserve command exit outcomes through the normal tool authorization path
- mark failed durable Web tasks and evidence from the structured result, including command aliases
- cover non-zero recovered commands and zero-exit Web commands

## Validation
- `python -m unittest tests.test_durable_tasks_gateway tests.test_tools -v`
- `make check`
- `make lint`
- `make docs-check`
- `make shell-check`
- `make test`