### PR TITLE
fix: reconcile task progress from execution receipts

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -417,7 +417,7 @@ CLI はアイドル時に 30 秒ごとに最大 4 機能をラウンドロビン
 
 OpenKyrozen v2 の長期メモリは **SQLite を事実上のソース**（`~/.kyrozen/v2/openkyrozen.sqlite3`）として使用し、ChromaDB は再構築可能な派生セマンティックインデックスです。個人の会話、タスク、学習はグローバル状態で共有されます。`FILE:` スナップショットとそのベクトルメタデータはアクティブなルートから計算した安定したスコープを使うため、プロジェクトを切り替えても別プロジェクトのファイルインデックスを削除・想起しません。既定のグローバルワークスペースは `~/.kyrozen/workspace` で、`kyrozen --project PATH` はミラーやコピー・バック層なしに元ファイルを直接操作します。Web/MCP の単一ユーザーデプロイでは、`KYROZEN_SERVER_TOKEN` が一つの安定した actor を表し、リクエストの `speaker` だけで private データの所有者を変更することはできません。
 
-タスクは再起動後も保存され、状態は `pending`、`running`、`succeeded`、`failed`、`blocked`、`cancelled` です（旧 `done` は読取互換）。`TaskDone` だけでは成功にならず、ツール結果、テスト、ファイル確認、または明示的な確認の証拠が必要です。安全な API タスクは worker が再開し、failed/blocked タスクは `/api/v2/tasks/{task_id}/resume` で明示的に再開します。
+タスクは再起動後も保存され、状態は `pending`、`running`、`succeeded`、`failed`、`blocked`、`cancelled` です（旧 `done` は読取互換）。`TaskDone` は完了リクエストにすぎず、成功したツール結果、テスト、ファイル確認、または明示的な確認による検証済み実行レシートが計画タスクを照合できます。同じチャットターン内で成功済みの状態変更操作を繰り返すことは拒否されます。安全な API タスクは worker が再開し、failed/blocked タスクは `/api/v2/tasks/{task_id}/resume` で明示的に再開します。
 
 プライベート claim は `speaker` を省略すると `KYROZEN_SERVER_ACTOR`（既定値
 `local`）に紐付きます。安定した actor を設定し、create → list → detail → forget
@@ -579,6 +579,7 @@ def register():
 | `KYROZEN_MODEL_SIMPLE` | 簡単/中程度タスク用モデル | プロバイダーデフォルト |
 | `KYROZEN_MODEL_COMPLEX` | 複雑タスク用モデル | プロバイダーデフォルト |
 | `KYROZEN_BASE_URL` | カスタム API ベース URL | プロバイダーデフォルト |
+| `KYROZEN_PROVIDER_TIMEOUT_SECONDS` | 1 回のプロバイダー応答の最大待機時間（秒） | `90` |
 | `KYROZEN_WORKSPACE_ROOT` | 高度なテスト/開発用ルート上書き。明示的な CLI オプションが優先 | `~/.kyrozen/workspace` |
 | `KYROZEN_DB_PATH` | SQLite の事実ストアのパス | `~/.kyrozen/v2/openkyrozen.sqlite3` |
 | `KYROZEN_VECTOR_PATH` | 再構築可能な Chroma インデックスのパス | SQLite ディレクトリ内 |

--- a/README.ko.md
+++ b/README.ko.md
@@ -417,7 +417,7 @@ CLI는 유휴 상태에서 30초마다 최대 4개 기능을 라운드 로빈으
 
 OpenKyrozen v2의 장기 메모리는 **SQLite를 사실의 원본**(`~/.kyrozen/v2/openkyrozen.sqlite3`)으로 사용하고, ChromaDB는 다시 만들 수 있는 파생 의미 인덱스로 사용합니다. 개인 대화, 작업과 학습은 전역 상태 저장소에서 공유됩니다. `FILE:` 스냅샷과 벡터 메타데이터는 활성 루트에서 계산한 안정적인 scope를 사용하므로 프로젝트를 바꿔도 다른 프로젝트의 파일 인덱스를 삭제하거나 불러오지 않습니다. 기본 전역 작업 공간은 `~/.kyrozen/workspace`이며 `kyrozen --project PATH`는 미러나 복사-복원 계층 없이 원본 프로젝트 파일을 직접 조작합니다. Web/MCP 단일 사용자 배포에서는 `KYROZEN_SERVER_TOKEN` 하나가 안정적인 actor 하나를 나타내고, 요청의 `speaker`만으로 private 데이터의 소유자를 바꿀 수 없습니다.
 
-작업은 재시작 후에도 저장되며 상태는 `pending`, `running`, `succeeded`, `failed`, `blocked`, `cancelled`입니다(이전 `done`은 읽기 호환). `TaskDone`만으로는 성공하지 않고 도구 결과, 테스트, 파일 확인 또는 명시적 확인 증거가 필요합니다. 안전한 API 작업은 worker가 재개하며 failed/blocked 작업은 `/api/v2/tasks/{task_id}/resume`으로 명시적으로 재개합니다.
+작업은 재시작 후에도 저장되며 상태는 `pending`, `running`, `succeeded`, `failed`, `blocked`, `cancelled`입니다(이전 `done`은 읽기 호환). `TaskDone`은 완료 요청일 뿐이며, 성공한 도구 결과, 테스트, 파일 확인 또는 명시적 확인의 검증된 실행 영수증이 계획 작업을 조정할 수 있습니다. 같은 채팅 턴에서 이미 성공한 상태 변경 작업을 반복하면 거부됩니다. 안전한 API 작업은 worker가 재개하며 failed/blocked 작업은 `/api/v2/tasks/{task_id}/resume`으로 명시적으로 재개합니다.
 
 private claim은 `speaker`를 생략하면 `KYROZEN_SERVER_ACTOR`(기본값 `local`)에
 연결됩니다. 안정적인 actor를 설정하고 같은 배포에서 create → list → detail →
@@ -578,6 +578,7 @@ def register():
 | `KYROZEN_MODEL_SIMPLE` | 간단/중간 작업용 모델 | 제공자 기본값 |
 | `KYROZEN_MODEL_COMPLEX` | 복잡한 작업용 모델 | 제공자 기본값 |
 | `KYROZEN_BASE_URL` | 사용자 정의 API 기본 URL | 제공자 기본값 |
+| `KYROZEN_PROVIDER_TIMEOUT_SECONDS` | 한 번의 제공자 응답을 기다리는 최대 시간(초) | `90` |
 | `KYROZEN_WORKSPACE_ROOT` | 고급 테스트/개발용 루트 재정의; 명시적 CLI 옵션이 우선 | `~/.kyrozen/workspace` |
 | `KYROZEN_DB_PATH` | SQLite 사실 저장소 경로 | `~/.kyrozen/v2/openkyrozen.sqlite3` |
 | `KYROZEN_VECTOR_PATH` | 재생성 가능한 Chroma 인덱스 경로 | SQLite 디렉터리 아래 |

--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ The migration creates a `.v1-backup` copy and writes the v2 database under `~/.k
 
 ### v2 durable tasks and learning
 
-Tasks persist across process restarts and use `pending`, `running`, `succeeded`, `failed`, `blocked`, and `cancelled` states. `TaskDone` is only a completion request; a successful tool result, test, file check, or explicit confirmation must provide evidence before a task can succeed. API-created tasks with an explicit safe `action` and string `args` are picked up by the durable worker after server restart; failed or blocked tasks require an explicit resume request.
+Tasks persist across process restarts and use `pending`, `running`, `succeeded`, `failed`, `blocked`, and `cancelled` states. `TaskDone` is only a completion request; a verified execution receipt from a successful tool result, test, file check, or explicit confirmation can reconcile a planned task. A repeated successful state-changing operation is refused within one chat turn. API-created tasks with an explicit safe `action` and string `args` are picked up by the durable worker after server restart; failed or blocked tasks require an explicit resume request.
 
 For model-generated complex work, give each `TaskList` item a stable `id` when the same turn can be retried; that ID is preferred over the description and is scoped to the authenticated user, workspace, and session. A `TaskList` update never clears recovered progress. `done` remains readable for old records but new progress and completion summaries use `succeeded`. `Plan`, `TaskList`, `TaskDone`, `Thought`, and `Action` are control blocks: the chat surface uses them internally and returns the latest natural-language response (or a deterministic tool/evidence summary), never a stale `Action` block.
 
@@ -800,6 +800,7 @@ See `plugins/turn_logger.py` for a working example.
 | `KYROZEN_MODEL_SIMPLE` | Model for simple/medium tasks | Provider default |
 | `KYROZEN_MODEL_COMPLEX` | Model for complex tasks | Provider default |
 | `KYROZEN_BASE_URL` | Custom API base URL | Provider default |
+| `KYROZEN_PROVIDER_TIMEOUT_SECONDS` | Maximum wait for one provider response | `90` |
 | `KYROZEN_WORKSPACE_ROOT` | Advanced test/development root override; explicit CLI mode flags take precedence | `~/.kyrozen/workspace` |
 | `KYROZEN_DB_PATH` | SQLite source-of-truth path | `~/.kyrozen/v2/openkyrozen.sqlite3` |
 | `KYROZEN_VECTOR_PATH` | Rebuildable Chroma index path | Under the SQLite directory |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -421,7 +421,7 @@ python main.py migrate v1 ./chroma_memory
 
 该命令会创建 `.v1-backup` 备份，并将 v2 数据写入 `~/.kyrozen/v2/`（也可通过 `KYROZEN_DB_PATH` 指定）。
 
-任务会跨重启保存，状态为 `pending`、`running`、`succeeded`、`failed`、`blocked` 或 `cancelled`；旧的 `done` 仍可读取。`TaskDone` 只是完成请求，只有工具结果、测试、文件检查或明确确认提供证据后，任务才会进入成功状态。API 创建的安全任务会由 worker 在重启后继续，failed/blocked 任务必须通过 `/api/v2/tasks/{task_id}/resume` 显式恢复。可使用 `/learning status`、`/learning explain <proposal_id>` 和 `/learning rollback <proposal_id>` 管理学习提案。
+任务会跨重启保存，状态为 `pending`、`running`、`succeeded`、`failed`、`blocked` 或 `cancelled`；旧的 `done` 仍可读取。`TaskDone` 只是完成请求；成功工具结果、测试、文件检查或明确确认生成的已验证执行回执可协调计划任务。同一聊天轮次会拒绝重复的已成功状态变更操作。API 创建的安全任务会由 worker 在重启后继续，failed/blocked 任务必须通过 `/api/v2/tasks/{task_id}/resume` 显式恢复。可使用 `/learning status`、`/learning explain <proposal_id>` 和 `/learning rollback <proposal_id>` 管理学习提案。
 
 Web/MCP 是单用户部署：一个 `KYROZEN_SERVER_TOKEN` 代表该部署唯一的私有 actor；请求体中的 `speaker` 不能伪造私有身份。私有记忆、任务、事件、计划和学习状态按该 actor、workspace、session 作用域隔离；共享部署的多个私有用户应使用不同部署和数据库。
 
@@ -587,6 +587,7 @@ def register():
 | `KYROZEN_MODEL_SIMPLE` | 简单/中等任务模型 | 服务商默认值 |
 | `KYROZEN_MODEL_COMPLEX` | 复杂任务模型 | 服务商默认值 |
 | `KYROZEN_BASE_URL` | 自定义 API 基础 URL | 服务商默认值 |
+| `KYROZEN_PROVIDER_TIMEOUT_SECONDS` | 单次服务商响应的最长等待时间（秒） | `90` |
 | `KYROZEN_WORKSPACE_ROOT` | 高级测试/开发根目录覆盖；显式 CLI 参数优先 | `~/.kyrozen/workspace` |
 | `KYROZEN_DB_PATH` | SQLite 事实主库路径 | `~/.kyrozen/v2/openkyrozen.sqlite3` |
 | `KYROZEN_VECTOR_PATH` | 可重建的 Chroma 索引路径 | SQLite 目录下 |

--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **147 unittest cases**.
+Current repository test count at this snapshot: **149 unittest cases**.
 
 ## Verified surface
 

--- a/docs/tool-inventory.md
+++ b/docs/tool-inventory.md
@@ -21,7 +21,7 @@ Run `make docs-check` after changing a tool, endpoint, or MCP contract.
 | `browser_snapshot` | `browser` | Read the current page text. Args: browser session ID. | `session_id`: string; required: `session_id` |
 | `browser_type` | `browser` | Fill a selector. Args format: session_id\|CSS selector\|text. | `session_id`: string, `selector`: string, `text`: string; required: `session_id`, `selector`, `text` |
 | `check_stored_data` | `read` | Return a categorized summary of stored memories. | `args`: string |
-| `execute_terminal_command` | `shell` | Execute a shell command and retain its machine-readable outcome. | `command`: string; required: `command` |
+| `execute_terminal_command` | `shell` | Execute a terminal command. This is an alias for run_cmd. | `command`: string; required: `command` |
 | `find_files` | `read` | Find files matching a pattern. Args format: "pattern" or "pattern\|directory". | `pattern`: string, `directory`: string; required: `pattern` |
 | `git_add` | `git` | Stage files for commit. Args format: "file1 file2" or "." (stage all). | `args`: string |
 | `git_branch` | `dynamic` | List or manage git branches. Args format: "" (list all), "branch_name" (create), | `args`: string |
@@ -41,7 +41,7 @@ Run `make docs-check` after changing a tool, endpoint, or MCP contract.
 | `list_tree` | `read` | Recursively list the directory tree of the given path. Args format: "path" (default "."). | `path`: string |
 | `read_file` | `read` | Read content from a file. Args format: "path". | `path`: string; required: `path` |
 | `read_webpage` | `network` | Fetch the content of a web page and return its plain‑text body. | `url`: string; required: `url` |
-| `run_cmd` | `shell` | Execute a shell command and retain its machine-readable outcome. | `command`: string; required: `command` |
+| `run_cmd` | `shell` | Execute a shell command. Args: the full command string. | `command`: string; required: `command` |
 | `search_memory` | `read` | Search stored memories for facts relevant to the query. Args: "query" | `args`: string |
 | `search_web` | `network` | Search the internet for real-time information. | `query`: string; required: `query` |
 | `write_file` | `write` | Write content to a file. Args format: "path\|content". | `path`: string, `content`: string; required: `path`, `content` |

--- a/main.py
+++ b/main.py
@@ -61,10 +61,12 @@ else:               _SPINNER_FRAMES = ["/", "-", "\\", "|"];             _BAR_FI
 import ast
 import json
 import os
+import queue
 import re
 import subprocess
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
 
 # macOS: suppress "MallocStackLogging: can't turn off malloc stack logging"
 # warnings from child Python processes spawned during self-learning
@@ -92,7 +94,7 @@ from rich import print as rprint
 
 from memory import MemoryBank
 from task_engine import TaskManager, TaskWorker, canonical_status, is_complete, is_terminal
-from event_store import stable_hash
+from event_store import stable_hash, utc_now
 from learning_engine import LearningEngine
 from skill_registry import SkillRegistry
 from instruction_loader import format_instructions
@@ -103,7 +105,7 @@ from dynamic_tools import SAFE_BUILTINS, validate_tool_source
 from plugin_runtime import get_plugin_runtime
 from workspace_context import LaunchContext, resolve_launch_context, source_scope_id
 from tools import (AVAILABLE_TOOLS, set_workspace_root as _set_tools_workspace_root,
-                   CommandResult, resolve_capabilities, tool_capability)
+                   CommandResult, run_command, resolve_capabilities, tool_capability)
 from providers import (
     ProviderConfig, LLMProvider, get_provider, detect_provider,
     save_provider_config, PROVIDER_DEFAULT_MODELS, PROVIDER_ENV_VARS,
@@ -2994,8 +2996,111 @@ def _notify_tool_execute(action: str, args: Any, result: Any) -> None:
         pass
 
 
-def _run_tool(action: str, args: str, *, return_success: bool = False) -> str | tuple[str, bool]:
-    def finish(result: str, success: bool = False) -> str | tuple[str, bool]:
+@dataclass(frozen=True)
+class ExecutionReceipt:
+    """Authoritative, bounded result of one tool attempt."""
+
+    receipt_id: str
+    operation_id: str
+    action: str
+    args: str
+    authorized: bool
+    started_at: str
+    completed_at: str
+    success: bool
+    result: str
+    failure: str | None = None
+    exit_code: int | None = None
+    verified_effect: str | None = None
+    acceptance: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "receipt_id": self.receipt_id,
+            "operation_id": self.operation_id,
+            "action": self.action,
+            "args": self.args,
+            "authorized": self.authorized,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+            "success": self.success,
+            "result": self.result,
+            "failure": self.failure,
+            "exit_code": self.exit_code,
+            "verified_effect": self.verified_effect,
+            "acceptance": self.acceptance,
+        }
+
+
+def _operation_action(action: str) -> str:
+    """Normalise aliases that perform the same state-changing operation."""
+    action = TOOL_ALIASES.get(str(action).strip(), str(action).strip())
+    return "run_cmd" if action == "execute_terminal_command" else action
+
+
+def _operation_args(action: str, args: Any) -> str:
+    value = str(args)
+    return value.strip() if action == "run_cmd" else value
+
+
+def _operation_id(scope: str, action: str, args: Any) -> str:
+    canonical = _operation_action(action)
+    return stable_hash(f"{scope}\0{canonical}\0{_operation_args(canonical, args)}")[:32]
+
+
+def _is_state_changing_action(action: str, args: str) -> bool:
+    action = _operation_action(action)
+    if action == "git_branch":
+        return bool(str(args).strip()) and not str(args).lstrip().startswith(("-a", "-v"))
+    if action == "git_remote":
+        return str(args).lstrip().startswith(("add ", "remove "))
+    return action in {
+        "write_file", "run_cmd", "git_clone", "git_add", "git_commit", "git_push",
+        "git_pull", "git_checkout", "git_stash", "git_reset", "git_remote", "define_tool",
+    }
+
+
+def _make_execution_receipt(*, action: str, args: Any, authorized: bool, started_at: str,
+                            success: bool, result: Any, operation_scope: str,
+                            failure: str | None = None, raw_result: Any = None) -> ExecutionReceipt:
+    canonical = _operation_action(action)
+    result_text = _fix_safe_text(result, 2000)
+    command = raw_result if isinstance(raw_result, CommandResult) else None
+    if command is not None:
+        failure = command.failure
+    effect, effect_verified = _subagent_tool_evidence(canonical, str(args), result_text)
+    acceptance, accepted = _acceptance_for_tool(canonical, str(args), result_text)
+    if not accepted and effect_verified:
+        acceptance = effect
+    return ExecutionReceipt(
+        receipt_id=f"receipt_{uuid.uuid4().hex}",
+        operation_id=_operation_id(operation_scope, canonical, args),
+        action=canonical,
+        args=_fix_safe_text(_operation_args(canonical, args), 1000),
+        authorized=authorized,
+        started_at=started_at,
+        completed_at=utc_now(),
+        success=bool(success),
+        result=result_text,
+        failure=failure if not success else None,
+        exit_code=command.exit_code if command is not None else None,
+        verified_effect=effect if effect_verified else None,
+        acceptance=acceptance if success and (accepted or effect_verified) else None,
+    )
+
+
+def _run_tool(action: str, args: str, *, return_success: bool = False,
+              return_receipt: bool = False, operation_scope: str = "") -> str | tuple[str, bool] | ExecutionReceipt:
+    started_at = utc_now()
+
+    def finish(result: str, success: bool = False, authorized: bool = False,
+               failure: str | None = None, raw_result: Any = None) -> str | tuple[str, bool] | ExecutionReceipt:
+        if return_receipt:
+            return _make_execution_receipt(
+                action=action, args=args, authorized=authorized, started_at=started_at,
+                success=success, result=result, operation_scope=operation_scope, failure=failure,
+                raw_result=raw_result,
+            )
         return (result, success) if return_success else result
 
     # Map aliases
@@ -3031,7 +3136,7 @@ def _run_tool(action: str, args: str, *, return_success: bool = False) -> str | 
     if not fn:
         result = f"Error: unknown tool '{action}'"
         _notify_tool_execute(action, args, result)
-        return finish(result)
+        return finish(result, failure="unknown_tool")
     required_capability = tool_capability(action)
     try:
         if required_capability not in effective_capabilities(load_agent_config(_get_workspace_root())):
@@ -3040,37 +3145,107 @@ def _run_tool(action: str, args: str, *, return_success: bool = False) -> str | 
                 "which is outside the configured agent capability bound"
             )
             _notify_tool_execute(action, args, result)
-            return finish(result)
+            return finish(result, failure="capability_denied")
     except AgentConfigError as exc:
         result = f"Error: invalid agent configuration: {exc}"
         _notify_tool_execute(action, args, result)
-        return finish(result)
+        return finish(result, failure="invalid_configuration")
     if not _execution_capability_token.allows(required_capability):
         result = f"Error: tool '{action}' requires capability '{required_capability}'"
         _notify_tool_execute(action, args, result)
-        return finish(result)
+        return finish(result, failure="capability_denied")
     if not _confirm_tool_action(action, str(args)):
         result = (
             f"Error: {action} requires confirmation. "
             "Approve it interactively or set KYROZEN_APPROVAL_MODE=never for an explicitly automated CLI."
         )
         _notify_tool_execute(action, args, result)
-        return finish(result)
+        return finish(result, failure="approval_denied")
     start = time.time()
+    tool_result: Any = None
+    failure: str | None = None
     try:
-        tool_result = fn(args)
+        tool_result = run_command(args) if action in {"run_cmd", "execute_terminal_command"} else fn(args)
         result = str(tool_result)
         success = tool_result.success if isinstance(tool_result, CommandResult) else not _is_tool_error(result)
     except KeyboardInterrupt:
         result = "Tool execution interrupted by user (Ctrl+C)."
         success = False
+        failure = "interrupted"
     except Exception as e:
         result = f"Error: {e}"
         success = False
+        failure = "execution_error"
     elapsed = time.time() - start
     _track_tool_performance(action, result, elapsed)
     _notify_tool_execute(action, args, result)
-    return finish(result, success)
+    return finish(result, success, authorized=True, failure=failure, raw_result=tool_result)
+
+
+def _execute_turn_action(action: str, args: Any, *, operation_scope: str,
+                         successful_operations: set[str]) -> ExecutionReceipt:
+    """Execute one model action, refusing a duplicate successful mutation."""
+    canonical = _operation_action(action)
+    started_at = utc_now()
+    if isinstance(args, dict):
+        result = (
+            f"Error: `{action}` requires a plain string as the `args` field.\n"
+            "You passed a JSON object. Convert to a plain string.\n"
+            "Example: `\"args\": \"python3 process_logs.py\"`.\n"
+            "Do NOT use `\"args\": {\"cmd\": ...}`.\n"
+        )
+        _notify_tool_execute(action, args, result)
+        return _make_execution_receipt(
+            action=canonical, args=args, authorized=False, started_at=started_at, success=False,
+            result=result, operation_scope=operation_scope, failure="invalid_arguments",
+        )
+    args = str(args)
+    operation_id = _operation_id(operation_scope, canonical, args)
+    if _is_state_changing_action(canonical, args) and operation_id in successful_operations:
+        result = "Error: duplicate successful state-changing action refused for this turn."
+        _notify_tool_execute(canonical, args, result)
+        return _make_execution_receipt(
+            action=canonical, args=args, authorized=True, started_at=started_at, success=False,
+            result=result, operation_scope=operation_scope, failure="duplicate_operation",
+        )
+    receipt = _run_tool(canonical, args, return_receipt=True, operation_scope=operation_scope)
+    assert isinstance(receipt, ExecutionReceipt)
+    if receipt.success and _is_state_changing_action(receipt.action, args):
+        successful_operations.add(receipt.operation_id)
+    return receipt
+
+
+def _record_turn_receipt(receipt: ExecutionReceipt) -> dict[str, Any]:
+    """Persist a receipt and reconcile the current planned task from verified evidence."""
+    task_id = tasks.active_task_id()
+    if task_id:
+        task = next(task for task in tasks.tasks if task["id"] == task_id)
+        checkpoint = task.get("checkpoint", {})
+        checkpoint_action = checkpoint.get("action")
+        if checkpoint_action and (
+            _operation_action(checkpoint_action) != receipt.action
+            or _operation_args(receipt.action, checkpoint.get("args", "")) != receipt.args
+        ):
+            task_id = None
+        elif not checkpoint_action:
+            tasks.update_checkpoint(task_id, {"action": receipt.action, "args": receipt.args})
+    evidence = tasks.record_evidence(
+        task_id=task_id, action=receipt.action, args=receipt.args, result=receipt.result,
+        success=receipt.success, acceptance=receipt.acceptance, receipt_id=receipt.receipt_id,
+    )
+    if task_id and receipt.success and receipt.acceptance:
+        index = next(index for index, task in enumerate(tasks.tasks) if task["id"] == task_id)
+        tasks.set_status(index, "succeeded")
+    tasks.store.append_event(
+        "execution.receipt", receipt.as_dict(), user_id=tasks.user_id,
+        workspace_id=tasks.workspace_id, session_id=tasks.session_id, task_id=task_id,
+    )
+    return {
+        "receipt_id": receipt.receipt_id, "operation_id": receipt.operation_id,
+        "action": receipt.action, "args": receipt.args, "result": receipt.result,
+        "success": receipt.success, "authorized": receipt.authorized,
+        "acceptance": receipt.acceptance, "failure": receipt.failure,
+    }
 
 
 def _execute_durable_task(task: dict[str, Any]) -> dict[str, Any]:
@@ -3183,6 +3358,33 @@ def _select_model(user_input: str) -> str:
     return DEEPSEEK_MODEL_SIMPLE
 
 
+def _provider_timeout_seconds() -> float:
+    try:
+        return max(1.0, min(float(os.environ.get("KYROZEN_PROVIDER_TIMEOUT_SECONDS", "90")), 600.0))
+    except ValueError:
+        return 90.0
+
+
+def _bounded_provider_call(callback: Any) -> Any:
+    """Return a provider result by deadline without leaving the CLI waiting on its SDK."""
+    outcome: queue.Queue[tuple[bool, Any]] = queue.Queue(maxsize=1)
+
+    def run() -> None:
+        try:
+            outcome.put((True, callback()))
+        except Exception as exc:
+            outcome.put((False, exc))
+
+    threading.Thread(target=run, daemon=True).start()
+    try:
+        succeeded, value = outcome.get(timeout=_provider_timeout_seconds())
+    except queue.Empty as exc:
+        raise TimeoutError(f"Provider timed out after {_provider_timeout_seconds():g}s") from exc
+    if not succeeded:
+        raise value
+    return value
+
+
 def _get_llm_response(messages: list[dict[str, str]], model: str | None = None, stream: bool = False) -> str:
     global _last_prompt_tokens, _last_completion_tokens, _total_prompt_tokens, _total_completion_tokens
     if llm_provider is None:
@@ -3199,7 +3401,9 @@ def _get_llm_response(messages: list[dict[str, str]], model: str | None = None, 
             _last_prompt_tokens = 0
             _last_completion_tokens = len(text) // 4  # rough estimate
         else:
-            text, usage_dict = llm_provider.chat(messages, model or DEEPSEEK_MODEL)
+            text, usage_dict = _bounded_provider_call(
+                lambda: llm_provider.chat(messages, model or DEEPSEEK_MODEL)
+            )
             if usage_dict:
                 _last_prompt_tokens = usage_dict.get("prompt_tokens", 0)
                 _last_completion_tokens = usage_dict.get("completion_tokens", 0)
@@ -3209,6 +3413,8 @@ def _get_llm_response(messages: list[dict[str, str]], model: str | None = None, 
                 _last_prompt_tokens = 0
                 _last_completion_tokens = 0
         return text
+    except TimeoutError as exc:
+        return f"[LLM Error] {exc}"
     except Exception as e:
         return f"[LLM Error] {e}"
 
@@ -3643,6 +3849,11 @@ def _chat_turn_impl(user_input: str, clear_tasks: bool = False, profile: str | N
         response_text = _call_llm_with_spinner(messages).strip()
         turn_prompt_total += _last_prompt_tokens
         turn_completion_total += _last_completion_tokens
+    if response_text.startswith("[LLM Error]"):
+        return _finish_learning_run(
+            learning_run, learning_receipts, user_input, response_text, [],
+            turn_prompt_total + turn_completion_total, turn_start,
+        )
 
     # Parse and observe each model response once.  Keep the raw response for
     # model context; use the parsed clean field for anything user-facing.
@@ -3787,35 +3998,16 @@ def _chat_turn_impl(user_input: str, clear_tasks: bool = False, profile: str | N
 
     results: list[str] = []
     tool_records: list[dict[str, Any]] = []
+    successful_operations: set[str] = set()
+    operation_scope = str(learning_run.get("run_id") or uuid.uuid4().hex)
     for tc in tool_calls:
-        action = tc.get("action", "")
-        args = tc.get("args", "")
-        if isinstance(args, dict):
-            result = (
-                f"Error: `{action}` requires a plain string as the `args` field.\n"
-                "You passed a JSON object. Convert to a plain string.\n"
-                "Example: `\"args\": \"python3 process_logs.py\"`\n"
-                "Do NOT use `\"args\": {\"cmd\": ...}`.\n"
-            )
-            _notify_tool_execute(action, args, result)
-        else:
-            if not isinstance(args, str):
-                args = str(args)
-            result = _run_tool(action, args)
-        safe_result = str(result)[:2000]
-        acceptance, accepted = _acceptance_for_tool(action, str(args), safe_result)
-        tasks.record_evidence(
-            task_id=tasks.active_task_id(),
-            action=action,
-            result=safe_result,
-            success=not _is_tool_error(safe_result),
-            acceptance=acceptance if accepted else None,
+        receipt = _execute_turn_action(
+            tc.get("action", ""), tc.get("args", ""), operation_scope=operation_scope,
+            successful_operations=successful_operations,
         )
-        tool_records.append({"action": action, "args": str(args)[:500], "result": safe_result,
-                             "success": accepted if acceptance else not _is_tool_error(safe_result),
-                             "acceptance": acceptance})
-        console.print(Panel(rich_escape(safe_result), title=f"Tool: {action}", border_style=_ACCENT_DIM, title_align="left"))
-        results.append(f"- `{action}({args!r})` returned:\n{_safe_fstring(safe_result)}")
+        tool_records.append(_record_turn_receipt(receipt))
+        console.print(Panel(rich_escape(receipt.result), title=f"Tool: {receipt.action}", border_style=_ACCENT_DIM, title_align="left"))
+        results.append(f"- `{receipt.action}({receipt.args!r})` returned:\n{_safe_fstring(receipt.result)}")
         if tasks.tasks:
             _update_tasks_panel()
     all_tool_result_lines = list(results)
@@ -3827,9 +4019,9 @@ def _chat_turn_impl(user_input: str, clear_tasks: bool = False, profile: str | N
     incomplete_prompt_attempts = 0
     final_answer: str | None = None
     current_reply = response_text
-    has_errors = any(_is_tool_error(r) for r in results)
+    has_errors = any(not record["success"] for record in tool_records)
     consecutive_search_failures = 0  # track failed search_web calls to prevent loops
-    total_search_calls = len([r for r in results if "search_web" in r])
+    total_search_calls = sum(record["action"] == "search_web" for record in tool_records)
     # check for missing arguments errors
     _args_missing_errors = [
         "requires a command",
@@ -3935,6 +4127,12 @@ def _chat_turn_impl(user_input: str, clear_tasks: bool = False, profile: str | N
         turn_prompt_total += _last_prompt_tokens
         turn_completion_total += _last_completion_tokens
         if not step_reply:
+            break
+        if step_reply.startswith("[LLM Error]"):
+            for index, task in enumerate(tasks.tasks):
+                if canonical_status(task["status"]) in {"pending", "running"}:
+                    tasks.set_status(index, "blocked")
+            final_answer = step_reply
             break
 
         # Observe this response once.  The same parsed result drives task
@@ -4055,41 +4253,21 @@ def _chat_turn_impl(user_input: str, clear_tasks: bool = False, profile: str | N
         next_results: list[str] = []
         has_errors = False
         for tc2 in next_tool_calls:
-            action = tc2.get("action", "")
-            args = tc2.get("args", "")
-            if isinstance(args, dict):
-                result2 = (
-                    f"Error: `{action}` requires a plain string as the `args` field.\n"
-                    "You passed a JSON object. Convert to a plain string.\n"
-                    "Example: `\"args\": \"python3 process_logs.py\"`\n"
-                    "Do NOT use `\"args\": {\"cmd\": ...}`.\n"
-                )
-                _notify_tool_execute(action, args, result2)
-            else:
-                if not isinstance(args, str):
-                    args = str(args)
-                try:
-                    result2 = _run_tool(action, args)
-                except KeyboardInterrupt:
-                    result2 = "Tool execution interrupted by user (Ctrl+C)."
-            safe_result2 = str(result2)[:2000]
-            acceptance, accepted = _acceptance_for_tool(action, str(args), safe_result2)
-            tasks.record_evidence(task_id=tasks.active_task_id(), action=action, result=safe_result2,
-                                  success=not _is_tool_error(safe_result2),
-                                  acceptance=acceptance if accepted else None)
-            tool_records.append({"action": action, "args": str(args)[:500], "result": safe_result2,
-                                 "success": accepted if acceptance else not _is_tool_error(safe_result2),
-                                 "acceptance": acceptance})
-            console.print(Panel(rich_escape(safe_result2), title=f"Tool: {action}", border_style=_ACCENT_DIM, title_align="left"))
-            next_results.append(f"- `{action}({args!r})` returned:\n{_safe_fstring(safe_result2)}")
+            receipt = _execute_turn_action(
+                tc2.get("action", ""), tc2.get("args", ""), operation_scope=operation_scope,
+                successful_operations=successful_operations,
+            )
+            tool_records.append(_record_turn_receipt(receipt))
+            console.print(Panel(rich_escape(receipt.result), title=f"Tool: {receipt.action}", border_style=_ACCENT_DIM, title_align="left"))
+            next_results.append(f"- `{receipt.action}({receipt.args!r})` returned:\n{_safe_fstring(receipt.result)}")
             if tasks.tasks:
                 _update_tasks_panel()
-            if _is_tool_error(result2):
+            if not receipt.success:
                 has_errors = True
             # Track search_web failures to prevent infinite search loops
-            if action == "search_web":
+            if receipt.action == "search_web":
                 total_search_calls += 1
-                if _is_tool_error(result2) or "Search temporarily unavailable" in str(result2):
+                if not receipt.success or "Search temporarily unavailable" in receipt.result:
                     consecutive_search_failures += 1
                 else:
                     consecutive_search_failures = 0  # reset on success

--- a/tests/test_task_consistency.py
+++ b/tests/test_task_consistency.py
@@ -1,4 +1,5 @@
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -120,6 +121,98 @@ class TaskConsistencyTests(unittest.TestCase):
             self.assertIn("Both files were written successfully.", reply)
             self.assertNotIn("Action:", reply)
             self.assertNotIn("Plan:", reply)
+
+    def test_receipts_complete_verified_task_and_refuse_duplicate_write(self):
+        class StubLearning:
+            def feedback_signal(self, _text):
+                return None
+
+            def route_profile(self, _text, _profile=None):
+                return "coder"
+
+            def begin_run(self, profile, _task, provider_model=None):
+                return {"run_id": "receipt-run", "profile": profile, "provider_model": provider_model}
+
+            def artifact_context(self, _run):
+                return "", []
+
+        responses = [
+            "Plan:\n1. Create the repeat marker\nTaskList:\n```json\n"
+            "[{\"id\": \"marker\", \"description\": \"Create the repeat marker\"}]\n```\n"
+            'Action: {"action":"write_file","args":"repeat-marker.txt|REPEAT_OK"}',
+            'Action: {"action":"write_file","args":"repeat-marker.txt|REPEAT_OK"}',
+            "The marker is complete.",
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            original_root = main._get_workspace_root()
+            original_tasks = main.tasks
+            original_learning = main.learning_engine
+            original_write = main.AVAILABLE_TOOLS["write_file"]
+            writes: list[str] = []
+
+            def counted_write(args: str) -> str:
+                writes.append(args)
+                return original_write(args)
+
+            main._set_workspace_root(root)
+            store = MemoryBank(root / "state.sqlite3").store
+            main.tasks = TaskManager(store, workspace_id="project", session_id="receipt-test")
+            main.learning_engine = StubLearning()
+            try:
+                with patch.object(main, "_classify_complexity", return_value="complex"), \
+                     patch.object(main, "_build_messages", return_value=[]), \
+                     patch.object(main, "_build_memory_context", return_value=""), \
+                     patch.object(main, "_call_llm_with_spinner", side_effect=responses), \
+                     patch.object(main, "_get_llm_response", return_value=""), \
+                     patch.object(main, "_update_tasks_panel"), \
+                     patch.object(main, "_finish_learning_run", side_effect=lambda run, receipts, task,
+                                  result, records, tokens, started: result), \
+                     patch.dict(main.AVAILABLE_TOOLS, {"write_file": counted_write}):
+                    reply = main._chat_turn("Create the repeat marker", clear_tasks=True)
+            finally:
+                main._set_workspace_root(original_root)
+                main.tasks = original_tasks
+                main.learning_engine = original_learning
+
+            self.assertEqual(writes, ["repeat-marker.txt|REPEAT_OK"])
+            self.assertEqual((root / "repeat-marker.txt").read_text(encoding="utf-8"), "REPEAT_OK")
+            self.assertEqual(store.list_tasks(workspace_id="project", session_id="receipt-test")[0]["status"], "succeeded")
+            receipts = store.list_events("execution.receipt", workspace_id="project", session_id="receipt-test")
+            self.assertEqual(len(receipts), 2)
+            self.assertEqual({item["payload"]["operation_id"] for item in receipts},
+                             {receipts[0]["payload"]["operation_id"]})
+            self.assertEqual({item["payload"]["success"] for item in receipts}, {True, False})
+            self.assertIn("duplicate_operation", {item["payload"]["failure"] for item in receipts})
+            self.assertIn("marker is complete", reply.lower())
+
+    def test_failed_operation_can_retry_and_provider_deadline_is_honest(self):
+        operations: set[str] = set()
+        with patch.object(main, "run_command", side_effect=[
+            main.CommandResult("Exit code 1", False, 1, "nonzero_exit"),
+            main.CommandResult("(no output)", True, 0),
+        ]):
+            failed = main._execute_turn_action("run_cmd", "python -c pass", operation_scope="retry", successful_operations=operations)
+            retried = main._execute_turn_action("run_cmd", "python -c pass", operation_scope="retry", successful_operations=operations)
+        self.assertFalse(failed.success)
+        self.assertEqual(failed.failure, "nonzero_exit")
+        self.assertTrue(retried.success)
+
+        class SlowProvider:
+            def chat(self, _messages, _model):
+                time.sleep(0.2)
+                return "late", None
+
+        original_provider = main.llm_provider
+        main.llm_provider = SlowProvider()
+        try:
+            with patch.object(main, "_provider_timeout_seconds", return_value=0.01):
+                started = time.monotonic()
+                response = main._get_llm_response([])
+        finally:
+            main.llm_provider = original_provider
+        self.assertLess(time.monotonic() - started, 0.1)
+        self.assertIn("Provider timed out", response)
 
 
 if __name__ == "__main__":

--- a/tools.py
+++ b/tools.py
@@ -999,7 +999,7 @@ def browser_close(args: str) -> str:
 AVAILABLE_TOOLS: dict[str, Any] = {
     "write_file": write_file,
     "read_file": read_file,
-    "run_cmd": run_command,
+    "run_cmd": run_cmd,
     "search_web": search_web,
     "find_files": find_files,
     "list_dir": list_dir,
@@ -1017,7 +1017,7 @@ AVAILABLE_TOOLS: dict[str, Any] = {
     "git_reset": git_reset,
     "git_show": git_show,
     "git_remote": git_remote,
-    "execute_terminal_command": run_command,
+    "execute_terminal_command": execute_terminal_command,
     "analyze_remote_repo": analyze_remote_repo,
     "list_tree": list_tree,
     "read_webpage": read_webpage,


### PR DESCRIPTION
Fixes #80

## Summary
- record canonical, authorized tool outcomes with stable operation identities and bounded redacted evidence
- reconcile verified planned work from receipts instead of optional `TaskDone` formatting
- reject repeated successful state-changing operations per turn while retaining failed retries and a bounded provider wait

## Validation
- `python -m unittest tests.test_task_consistency tests.test_durable_tasks_gateway tests.test_bugfix_workflow tests.test_server -v`
- `make check`
- `make lint`
- `make docs-check`
- `make shell-check`
- `make test` (149 tests)