### PR TITLE
fix: initialize fresh MCP chat sessions

### DIFF
--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **149 unittest cases**.
+Current repository test count at this snapshot: **150 unittest cases**.
 
 ## Verified surface
 

--- a/server.py
+++ b/server.py
@@ -270,9 +270,20 @@ def _normalise_memory_context(speaker: Any, audience: Any, channel: Any) -> tupl
     return speaker, audience, channel
 
 
-def _set_memory_context(session: dict[str, Any], body: dict[str, Any]) -> None:
+def _initialise_session_defaults(session: dict[str, Any]) -> None:
+    """Apply the server-owned memory authority required by every chat surface."""
     default = _SERVER_ACTOR_ID
     session["user_id"] = default
+    session.setdefault("profile", "auto")
+    session.setdefault("speaker", default)
+    session.setdefault("audience", default)
+    session.setdefault("channel", "chat")
+    session["authorized_speakers"] = [default]
+
+
+def _set_memory_context(session: dict[str, Any], body: dict[str, Any]) -> None:
+    _initialise_session_defaults(session)
+    default = _SERVER_ACTOR_ID
     speaker = _normalise_memory_actor(body.get("speaker"), "speaker", session.get("speaker", default))
     audience = _normalise_memory_actor(body.get("audience"), "audience", session.get("audience", speaker))
     channel = _normalise_memory_actor(body.get("channel"), "channel", session.get("channel", "chat"))
@@ -314,7 +325,9 @@ def _get_or_create_session(session_id: str, user_id: str = "anonymous") -> dict:
             if len(_sessions) > 100:
                 oldest = min(_sessions, key=lambda k: _sessions[k]["created"])
                 del _sessions[oldest]
-        return _sessions[session_id]
+        session = _sessions[session_id]
+        _initialise_session_defaults(session)
+        return session
 
 
 def _run_session_chat(session: dict[str, Any], message: str) -> str:
@@ -1307,7 +1320,11 @@ async def mcp_endpoint(request: Request):
             return _mcp_error(request_id, -32602, "Empty message")
         session_id = _normalise_session_id(params.get("session_id"))
         session = _get_or_create_session(session_id, _SERVER_ACTOR_ID)
-        reply = _run_session_chat(session, msg)
+        try:
+            reply = _run_session_chat(session, msg)
+        except Exception as exc:
+            _audit("MCP_CHAT_ERROR", type(exc).__name__, _SERVER_ACTOR_ID)
+            return _mcp_error(request_id, -32603, "Internal error")
         return _mcp_response(request_id, result={"content": reply, "session_id": session_id})
     return _mcp_error(request_id, -32601, f"Unknown method: {method}")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -145,6 +145,35 @@ class ServerBoundaryTests(unittest.TestCase):
         self.assertEqual(method_error["id"], 24)
         self.assertEqual(method_error["error"]["code"], -32601)
 
+    def test_fresh_mcp_chat_uses_safe_defaults_and_redacts_internal_errors(self):
+        client = TestClient(server.app)
+        seen = {}
+
+        def reply(session, message):
+            seen.update(session)
+            self.assertEqual(message, "Reply with exactly MCP_CHAT_OK")
+            return "MCP_CHAT_OK"
+
+        with patch.object(server, "_run_session_chat", side_effect=reply):
+            fresh = client.post("/mcp", json={
+                "jsonrpc": "2.0", "id": 91, "method": "chat/send",
+                "params": {"message": "Reply with exactly MCP_CHAT_OK", "session_id": "fresh-mcp-test"},
+            })
+        self.assertEqual(fresh.status_code, 200, fresh.text)
+        self.assertEqual(fresh.json()["result"]["content"], "MCP_CHAT_OK")
+        self.assertEqual(seen["user_id"], server._SERVER_ACTOR_ID)
+        self.assertEqual(seen["speaker"], server._SERVER_ACTOR_ID)
+        self.assertEqual(seen["authorized_speakers"], [server._SERVER_ACTOR_ID])
+
+        with patch.object(server, "_run_session_chat", side_effect=RuntimeError("secret=must-not-leak")):
+            failed = client.post("/mcp", json={
+                "jsonrpc": "2.0", "id": 92, "method": "chat/send",
+                "params": {"message": "test", "session_id": "fresh-mcp-error"},
+            })
+        self.assertEqual(failed.status_code, 200, failed.text)
+        self.assertEqual(failed.json()["error"], {"code": -32603, "message": "Internal error"})
+        self.assertNotIn("must-not-leak", failed.text)
+
     def test_ollama_initialization_never_prompts_for_a_key(self):
         original_config = server._agent._provider_config
         original_provider = server._agent.llm_provider


### PR DESCRIPTION
Fixes #83

## Summary
- centralize server-owned memory/session defaults for REST, SSE, MCP, recovery, and UI paths
- bind private-memory authority to the deployment actor for every session
- turn unexpected MCP `chat/send` failures into redacted JSON-RPC internal errors

## Validation
- `python -m unittest tests.test_server -v`
- `make check`
- `make lint`
- `make docs-check`
- `make shell-check`
- `make test-core` (150 tests, one expected browser skip)