### PR TITLE
fix: restore durable web sessions

### DIFF
--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **150 unittest cases**.
+Current repository test count at this snapshot: **151 unittest cases**.
 
 ## Verified surface
 

--- a/server.py
+++ b/server.py
@@ -447,6 +447,12 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;backgrou
 header{background:#161b22;padding:12px 20px;border-bottom:1px solid #30363d;display:flex;align-items:center;gap:12px}
 header h1{font-size:18px;color:#00f0ff}
 header span{font-size:12px;color:#8b949e}
+#session-controls{background:#161b22;border-bottom:1px solid #30363d;display:flex;align-items:center;gap:8px;padding:8px 20px}
+#session-controls label,#session-limit{font-size:12px;color:#8b949e}
+#session-select{min-width:190px;max-width:45vw;background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#c9d1d9;padding:7px}
+#session-select:focus{outline:none;border-color:#00f0ff}
+#new-session{padding:7px 12px;font-size:12px}
+#session-limit{margin-left:auto}
 #chat{flex:1;overflow-y:auto;padding:20px}
 .msg{margin-bottom:16px;max-width:85%}
 .msg.user{margin-left:auto}
@@ -472,6 +478,12 @@ button:disabled{opacity:.4;cursor:default}
   <span>Self-learning AI Agent</span>
   <span class="cost" id="cost-display"></span>
 </header>
+<div id="session-controls">
+  <label for="session-select">Saved conversation</label>
+  <select id="session-select" aria-describedby="session-limit"></select>
+  <button type="button" id="new-session">New conversation</button>
+  <span id="session-limit" role="status"></span>
+</div>
 <div id="chat"></div>
 <div id="input-area">
   <textarea id="user-input" placeholder="Type your message..." rows="1" onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();sendMessage()}"></textarea>
@@ -479,8 +491,96 @@ button:disabled{opacity:.4;cursor:default}
 </div>
 <div id="status">Ready</div>
 <script>
-const sessionId = 'sess_' + Math.random().toString(36).slice(2,10);
+const SESSION_STORAGE_KEY = 'openkyrozen.active-session';
+const SESSION_LIST_LIMIT = 100;
+let sessionId = readActiveSession() || createSessionId();
+let recentSessions = [];
 let isStreaming = false;
+
+function createSessionId() {
+  const random = window.crypto && window.crypto.randomUUID
+    ? window.crypto.randomUUID().replace(/-/g, '')
+    : Math.random().toString(36).slice(2, 10);
+  return 'sess_' + random;
+}
+
+function readActiveSession() {
+  try { return localStorage.getItem(SESSION_STORAGE_KEY) || ''; } catch (_) { return ''; }
+}
+
+function saveActiveSession() {
+  try { localStorage.setItem(SESSION_STORAGE_KEY, sessionId); } catch (_) { /* storage is optional */ }
+}
+
+function clearChat() {
+  document.getElementById('chat').replaceChildren();
+}
+
+function renderSessionList(sessions) {
+  recentSessions = Array.isArray(sessions) ? sessions : [];
+  const select = document.getElementById('session-select');
+  select.replaceChildren();
+  const known = recentSessions.some(item => item.session_id === sessionId);
+  if (!known) {
+    const current = new Option('Current conversation', sessionId);
+    select.add(current);
+  }
+  for (const item of recentSessions) {
+    const option = new Option(item.session_id, item.session_id);
+    select.add(option);
+  }
+  select.value = sessionId;
+  document.getElementById('session-limit').textContent = recentSessions.length >= SESSION_LIST_LIMIT
+    ? 'Showing the newest 100 saved sessions. Older durable sessions remain saved.'
+    : `Showing ${recentSessions.length} saved sessions. Older durable history is never deleted here.`;
+}
+
+async function refreshSessionList() {
+  const response = await fetch(`/api/v2/sessions?limit=${SESSION_LIST_LIMIT}`);
+  if (!response.ok) throw new Error('Could not load saved conversations');
+  const data = await response.json();
+  renderSessionList(data.sessions);
+}
+
+async function restoreSession(nextSessionId) {
+  sessionId = nextSessionId;
+  saveActiveSession();
+  try {
+    const response = await fetch(`/api/v2/sessions/${encodeURIComponent(sessionId)}`);
+    if (!response.ok) throw new Error('Could not load this conversation');
+    const data = await response.json();
+    const messages = Array.isArray(data.messages) ? data.messages : [];
+    clearChat();
+    messages.forEach(message => addMessage(message.role, String(message.content), false));
+    renderSessionList(recentSessions);
+    document.getElementById('status').textContent = messages.length
+      ? `Restored ${messages.length} saved message${messages.length === 1 ? '' : 's'}.`
+      : 'No saved messages in this conversation.';
+  } catch (_) {
+    clearChat();
+    document.getElementById('status').textContent = 'Could not load this conversation.';
+  }
+}
+
+function startNewSession() {
+  if (isStreaming) return;
+  sessionId = createSessionId();
+  saveActiveSession();
+  clearChat();
+  renderSessionList(recentSessions);
+  document.getElementById('status').textContent = 'New conversation ready.';
+  document.getElementById('user-input').focus();
+}
+
+async function initialiseSessions() {
+  try {
+    await refreshSessionList();
+    await restoreSession(sessionId);
+  } catch (_) {
+    renderSessionList([]);
+    document.getElementById('status').textContent = 'Could not load saved conversations.';
+  }
+}
 
 function addMessage(role, content, isThinking) {
   const chat = document.getElementById('chat');
@@ -590,7 +690,14 @@ async function sendMessage() {
   isStreaming = false;
   btn.disabled = false;
   input.focus();
+  refreshSessionList().catch(() => {});
 }
+
+document.getElementById('session-select').addEventListener('change', event => {
+  if (!isStreaming) restoreSession(event.target.value);
+});
+document.getElementById('new-session').addEventListener('click', startNewSession);
+initialiseSessions();
 
 // Load cost on start
 fetch('/api/cost').then(r=>r.json()).then(d=>{

--- a/tests/test_web_sessions.py
+++ b/tests/test_web_sessions.py
@@ -1,0 +1,141 @@
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from event_store import EventStore
+
+
+class WebSessionBrowserTests(unittest.TestCase):
+    @staticmethod
+    def _free_port() -> int:
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            return int(sock.getsockname()[1])
+
+    @staticmethod
+    def _request(base_url: str, path: str) -> dict:
+        request = urllib.request.Request(base_url + path)
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    def _start_server(self, workspace: Path, db_path: Path, port: int) -> tuple[subprocess.Popen, str]:
+        repository = Path(__file__).parents[1]
+        env = os.environ.copy()
+        env.update({
+            "HOME": str(workspace / "home"),
+            "KYROZEN_DB_PATH": str(db_path),
+            "KYROZEN_DISABLE_VECTOR_INDEX": "1",
+            "KYROZEN_PROVIDER": "ollama",
+            "KYROZEN_BASE_URL": "http://127.0.0.1:11434/v1",
+        })
+        for variable in ("KYROZEN_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
+                         "KYROZEN_SERVER_TOKEN"):
+            env.pop(variable, None)
+        process = subprocess.Popen(
+            [sys.executable, str(repository / "server.py"), "--project", str(workspace),
+             "--host", "127.0.0.1", "--port", str(port)],
+            cwd=workspace, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+        )
+        base_url = f"http://127.0.0.1:{port}"
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                output = process.stdout.read() if process.stdout else ""
+                self.fail(f"Web server exited before becoming ready: {output}")
+            try:
+                if self._request(base_url, "/api/health").get("status") in {"ok", "degraded"}:
+                    return process, base_url
+            except (OSError, urllib.error.URLError):
+                time.sleep(0.1)
+        process.terminate()
+        process.wait(timeout=5)
+        self.fail("Web server did not become ready")
+
+    @staticmethod
+    def _stop_server(process: subprocess.Popen) -> None:
+        if process.poll() is None:
+            process.terminate()
+            process.wait(timeout=5)
+        if process.stdout:
+            process.stdout.close()
+
+    @unittest.skipUnless(
+        os.environ.get("KYROZEN_BROWSER_TESTS") == "1",
+        "browser integration requires `make install` (Playwright and Chromium)",
+    )
+    def test_browser_restores_switches_and_retains_durable_sessions_after_restart(self):
+        with tempfile.TemporaryDirectory(prefix="openkyrozen-web-sessions-") as directory:
+            root = Path(directory)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            (workspace / "home").mkdir()
+            db_path = root / "state.sqlite3"
+            store = EventStore(db_path)
+            for session_id, messages in {
+                "session-one": [("user", "first user"), ("assistant", "UI_你好_✅")],
+                "session-two": [("user", "second user"), ("assistant", "Second_会话_✅")],
+            }.items():
+                for role, content in messages:
+                    store.append_event(
+                        "session.message", {"role": role, "content": content},
+                        user_id="local", workspace_id="default", session_id=session_id,
+                    )
+
+            port = self._free_port()
+            process, base_url = self._start_server(workspace, db_path, port)
+            playwright = browser = None
+            try:
+                from playwright.sync_api import sync_playwright
+
+                playwright = sync_playwright().start()
+                browser = playwright.chromium.launch(headless=True)
+                page = browser.new_page()
+                page.add_init_script(
+                    "if (!localStorage.getItem('openkyrozen.active-session')) "
+                    "localStorage.setItem('openkyrozen.active-session', 'session-one');"
+                )
+                page.goto(base_url, wait_until="domcontentloaded")
+                page.wait_for_function("document.body.innerText.includes('UI_你好_✅')")
+                self.assertEqual(
+                    page.locator("#session-select").evaluate("element => element.labels[0].textContent"),
+                    "Saved conversation",
+                )
+                self.assertIn("durable history is never deleted", page.locator("#session-limit").text_content())
+
+                page.select_option("#session-select", "session-two")
+                page.wait_for_function("document.body.innerText.includes('Second_会话_✅')")
+                self.assertNotIn("first user", page.locator("#chat").inner_text())
+                page.reload(wait_until="domcontentloaded")
+                page.wait_for_function("document.body.innerText.includes('Second_会话_✅')")
+
+                self._stop_server(process)
+                process, base_url = self._start_server(workspace, db_path, port)
+                page.reload(wait_until="domcontentloaded")
+                page.wait_for_function("document.body.innerText.includes('Second_会话_✅')")
+                page.select_option("#session-select", "session-one")
+                page.wait_for_function("document.body.innerText.includes('UI_你好_✅')")
+
+                page.evaluate(
+                    "localStorage.setItem('openkyrozen.active-session', 'invalid/session'); location.reload();"
+                )
+                page.wait_for_function(
+                    "document.getElementById('status').textContent === 'Could not load this conversation.'"
+                )
+            finally:
+                if browser is not None:
+                    browser.close()
+                if playwright is not None:
+                    playwright.stop()
+                self._stop_server(process)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #81

Restores the active browser session from local storage, adds labeled native conversation controls, and loads durable history through the V2 session API. The UI states the deterministic recent-session view without pruning durable history.

Validation:
- make test (151 tests, including Chromium session reload/restart regression)
- make check
- make docs-check
- git diff --check