### PR TITLE
fix: persist usage accounting ledger

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -489,6 +489,7 @@ KYROZEN_SERVER_TOKEN=change-me kyrozen-web --host 0.0.0.0 --port 8000
 | `GET` | `/api/v2/agents` | 専用 sub-agent profile の一覧 |
 | `POST` | `/api/v2/agents/run` | 分離 memory と能力で sub-agent を実行 |
 | `GET` | `/api/cost` | token 使用量とコストサマリー |
+| `POST` | `/api/cost/reset` | durable な workspace/session 集計ウィンドウを明示的に reset（`confirm: "reset-cost"` が必要） |
 | `GET` | `/api/health` | provider 状態 + memory 件数 |
 | `GET` | `/api/voice/speak?text=...` | システム TTS でテキスト読み上げ |
 | `POST` | `/api/voice/transcribe` | 音声テキスト変換（パススルー） |

--- a/README.ko.md
+++ b/README.ko.md
@@ -488,6 +488,7 @@ KYROZEN_SERVER_TOKEN=change-me kyrozen-web --host 0.0.0.0 --port 8000
 | `GET` | `/api/v2/agents` | 전문 sub-agent profile 조회 |
 | `POST` | `/api/v2/agents/run` | 격리된 memory와 capability로 sub-agent 실행 |
 | `GET` | `/api/cost` | token 사용량 및 비용 요약 |
+| `POST` | `/api/cost/reset` | durable workspace/session 집계 창을 명시적으로 reset (`confirm: "reset-cost"` 필요) |
 | `GET` | `/api/health` | provider 상태 + memory 수 |
 | `GET` | `/api/voice/speak?text=...` | 시스템 TTS 텍스트 음성 변환 |
 | `POST` | `/api/voice/transcribe` | 음성-텍스트 변환 (패스스루) |

--- a/README.md
+++ b/README.md
@@ -608,6 +608,7 @@ KYROZEN_SERVER_TOKEN=change-me kyrozen-web --host 0.0.0.0 --port 8000
 | `POST` | `/api/chat` | Send a message with optional `profile`, `speaker`, `audience`, and `channel`; returns a memory receipt |
 | `POST` | `/api/chat/stream` | SSE streaming chat with the same optional profile and memory context |
 | `GET` | `/api/cost` | Token usage and cost summary |
+| `POST` | `/api/cost/reset` | Explicitly reset a durable workspace/session reporting window (requires `confirm: "reset-cost"`) |
 | `GET` | `/api/health` | Provider status + memory count |
 | `GET` | `/api/memory?q=keyword` | Search stored memories |
 | `GET` | `/api/v2/agents` | List specialised sub-agent profiles |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -491,6 +491,7 @@ KYROZEN_SERVER_TOKEN=change-me kyrozen-web --host 0.0.0.0 --port 8000
 | `GET` | `/api/v2/agents` | 查看专用子 Agent profile |
 | `POST` | `/api/v2/agents/run` | 使用独立记忆和权限运行子 Agent |
 | `GET` | `/api/cost` | Token 用量和费用摘要 |
+| `POST` | `/api/cost/reset` | 显式重置 durable workspace/session 统计窗口（需要 `confirm: "reset-cost"`） |
 | `GET` | `/api/health` | 服务商状态 + 记忆计数 |
 | `GET` | `/api/voice/speak?text=...` | 通过系统 TTS 进行文本转语音 |
 | `POST` | `/api/voice/transcribe` | 语音转文本（透传） |

--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **151 unittest cases**.
+Current repository test count at this snapshot: **154 unittest cases**.
 
 ## Verified surface
 

--- a/docs/tool-inventory.md
+++ b/docs/tool-inventory.md
@@ -57,6 +57,7 @@ Parameterized names are part of the contract; clients may substitute a value for
 | `POST` | `/api/chat` |
 | `POST` | `/api/chat/stream` |
 | `GET` | `/api/cost` |
+| `POST` | `/api/cost/reset` |
 | `GET` | `/api/health` |
 | `GET` | `/api/memory` |
 | `GET` | `/api/v2/agents` |

--- a/event_store.py
+++ b/event_store.py
@@ -29,7 +29,7 @@ def stable_hash(value: str) -> str:
 class EventStore:
     """Small transactional store shared by memory, tasks, and learning."""
 
-    SCHEMA_VERSION = 1
+    SCHEMA_VERSION = 2
 
     def __init__(self, path: str | os.PathLike[str] | None = None):
         configured = path or os.environ.get("KYROZEN_DB_PATH")
@@ -177,6 +177,40 @@ class EventStore:
                 );
                 CREATE INDEX IF NOT EXISTS idx_skills_status
                     ON skills(workspace_id, status, name);
+                CREATE TABLE IF NOT EXISTS usage_attempts (
+                    id TEXT PRIMARY KEY,
+                    provider TEXT NOT NULL,
+                    model TEXT NOT NULL,
+                    surface TEXT NOT NULL,
+                    user_id TEXT NOT NULL DEFAULT 'local',
+                    workspace_id TEXT NOT NULL DEFAULT 'default',
+                    session_id TEXT,
+                    run_id TEXT,
+                    cache_status TEXT NOT NULL DEFAULT 'unknown',
+                    prompt_tokens INTEGER,
+                    cache_hit_tokens INTEGER,
+                    cache_miss_tokens INTEGER,
+                    completion_tokens INTEGER,
+                    reasoning_tokens INTEGER,
+                    latency_ms INTEGER,
+                    completion_state TEXT NOT NULL,
+                    usage_status TEXT NOT NULL,
+                    cost_picos INTEGER,
+                    pricing_snapshot TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_usage_attempts_scope
+                    ON usage_attempts(user_id, workspace_id, session_id, created_at);
+                CREATE TABLE IF NOT EXISTS usage_resets (
+                    id TEXT PRIMARY KEY,
+                    scope TEXT NOT NULL,
+                    user_id TEXT NOT NULL DEFAULT 'local',
+                    workspace_id TEXT NOT NULL DEFAULT 'default',
+                    session_id TEXT,
+                    created_at TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_usage_resets_scope
+                    ON usage_resets(scope, user_id, workspace_id, session_id, created_at);
                 """
             )
             existing = db.execute("SELECT version FROM schema_migrations WHERE version=?", (self.SCHEMA_VERSION,)).fetchone()
@@ -246,6 +280,156 @@ class EventStore:
                 params,
             ).fetchall()
         return [dict(row) for row in rows]
+
+    def record_usage_attempt(
+            self, *, attempt_id: str, provider: str, model: str, surface: str,
+            user_id: str = "local", workspace_id: str = "default",
+            session_id: str | None = None, run_id: str | None = None,
+            cache_status: str = "unknown", prompt_tokens: int | None = None,
+            cache_hit_tokens: int | None = None, cache_miss_tokens: int | None = None,
+            completion_tokens: int | None = None, reasoning_tokens: int | None = None,
+            latency_ms: int | None = None, completion_state: str = "completed",
+            usage_status: str = "unknown", cost_picos: int | None = None,
+            pricing_snapshot: dict[str, Any] | None = None,
+    ) -> bool:
+        """Store one immutable provider attempt; duplicate IDs are harmless."""
+        def integer(value: int | None) -> int | None:
+            return None if value is None else max(0, int(value))
+
+        values = (
+            str(attempt_id)[:128], str(provider or "unknown")[:64], str(model or "unknown")[:128],
+            str(surface or "unknown")[:64], str(user_id or "local")[:128],
+            str(workspace_id or "default")[:256], str(session_id)[:128] if session_id else None,
+            str(run_id)[:128] if run_id else None, str(cache_status or "unknown")[:32],
+            integer(prompt_tokens), integer(cache_hit_tokens), integer(cache_miss_tokens),
+            integer(completion_tokens), integer(reasoning_tokens), integer(latency_ms),
+            str(completion_state or "unknown")[:32], str(usage_status or "unknown")[:32],
+            integer(cost_picos), self._json(pricing_snapshot or {}), utc_now(),
+        )
+        with self._lock, self.connection() as db:
+            return db.execute(
+                "INSERT OR IGNORE INTO usage_attempts("
+                "id,provider,model,surface,user_id,workspace_id,session_id,run_id,cache_status,"
+                "prompt_tokens,cache_hit_tokens,cache_miss_tokens,completion_tokens,reasoning_tokens,"
+                "latency_ms,completion_state,usage_status,cost_picos,pricing_snapshot,created_at"
+                ") VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                values,
+            ).rowcount == 1
+
+    def list_usage_attempts(
+            self, *, workspace_id: str | None = None, session_id: str | None = None,
+            user_id: str | None = None, limit: int = 1000,
+    ) -> list[dict[str, Any]]:
+        clauses = ["1=1"]
+        params: list[Any] = []
+        if workspace_id is not None:
+            clauses.append("workspace_id=?")
+            params.append(workspace_id)
+        if session_id is not None:
+            clauses.append("session_id=?")
+            params.append(session_id)
+        if user_id is not None:
+            clauses.append("user_id=?")
+            params.append(user_id)
+        params.append(max(1, min(limit, 10000)))
+        with self.connection() as db:
+            rows = db.execute(
+                f"SELECT * FROM usage_attempts WHERE {' AND '.join(clauses)} "
+                "ORDER BY created_at DESC LIMIT ?", params,
+            ).fetchall()
+        return [dict(row, pricing_snapshot=self._loads(row["pricing_snapshot"], {})) for row in rows]
+
+    def usage_totals(
+            self, *, workspace_id: str | None = None, session_id: str | None = None,
+            user_id: str | None = None, since: str | None = None,
+    ) -> dict[str, Any]:
+        """Aggregate immutable usage records for one explicit durable scope."""
+        clauses = ["1=1"]
+        params: list[Any] = []
+        for field, value in (("workspace_id", workspace_id), ("session_id", session_id),
+                             ("user_id", user_id)):
+            if value is not None:
+                clauses.append(f"{field}=?")
+                params.append(value)
+        if since:
+            clauses.append("created_at>?")
+            params.append(since)
+        columns = (
+            "COUNT(*) AS attempts, "
+            "SUM(CASE WHEN usage_status='authoritative' THEN 1 ELSE 0 END) AS authoritative_attempts, "
+            "SUM(CASE WHEN usage_status='estimated' THEN 1 ELSE 0 END) AS estimated_attempts, "
+            "SUM(COALESCE(prompt_tokens, 0)) AS prompt_tokens, "
+            "SUM(COALESCE(cache_hit_tokens, 0)) AS cache_hit_tokens, "
+            "SUM(COALESCE(cache_miss_tokens, 0)) AS cache_miss_tokens, "
+            "SUM(COALESCE(completion_tokens, 0)) AS completion_tokens, "
+            "SUM(COALESCE(reasoning_tokens, 0)) AS reasoning_tokens, "
+            "SUM(COALESCE(cost_picos, 0)) AS cost_picos"
+        )
+        with self.connection() as db:
+            total = db.execute(
+                f"SELECT {columns} FROM usage_attempts WHERE {' AND '.join(clauses)}", params,
+            ).fetchone()
+            by_provider = db.execute(
+                f"SELECT provider, {columns} FROM usage_attempts WHERE {' AND '.join(clauses)} "
+                "GROUP BY provider ORDER BY provider", params,
+            ).fetchall()
+
+        def normalise(row: sqlite3.Row | None) -> dict[str, int]:
+            names = ("attempts", "authoritative_attempts", "estimated_attempts", "prompt_tokens",
+                     "cache_hit_tokens", "cache_miss_tokens", "completion_tokens", "reasoning_tokens",
+                     "cost_picos")
+            values = {name: int((row[name] if row else 0) or 0) for name in names}
+            values["unknown_attempts"] = max(
+                0, values["attempts"] - values["authoritative_attempts"] - values["estimated_attempts"],
+            )
+            return values
+
+        return {
+            **normalise(total), "currency": "USD",
+            "providers": [dict(provider=row["provider"], **normalise(row)) for row in by_provider],
+        }
+
+    def create_usage_reset(
+            self, *, scope: str, user_id: str = "local", workspace_id: str = "default",
+            session_id: str | None = None,
+    ) -> dict[str, str]:
+        """Start a new reported usage window while retaining immutable attempts."""
+        if scope not in {"workspace", "session"}:
+            raise ValueError("usage reset scope must be workspace or session")
+        if scope == "session" and not session_id:
+            raise ValueError("session usage reset requires a session_id")
+        reset_id = f"usage_reset_{uuid.uuid4().hex}"
+        event_id = f"evt_{uuid.uuid4().hex}"
+        created_at = utc_now()
+        payload = {"reset_id": reset_id, "scope": scope}
+        with self._lock, self.connection() as db:
+            db.execute(
+                "INSERT INTO usage_resets(id,scope,user_id,workspace_id,session_id,created_at) VALUES(?,?,?,?,?,?)",
+                (reset_id, scope, user_id, workspace_id, session_id, created_at),
+            )
+            db.execute(
+                "INSERT INTO events(id,event_type,payload,user_id,workspace_id,session_id,task_id,created_at) "
+                "VALUES(?,?,?,?,?,?,?,?)",
+                (event_id, "usage.reset", self._json(payload), user_id, workspace_id,
+                 session_id, None, created_at),
+            )
+        return {"reset_id": reset_id, "created_at": created_at}
+
+    def latest_usage_reset(
+            self, *, scope: str, user_id: str = "local", workspace_id: str = "default",
+            session_id: str | None = None,
+    ) -> dict[str, Any] | None:
+        clauses = ["scope=?", "user_id=?", "workspace_id=?"]
+        params: list[Any] = [scope, user_id, workspace_id]
+        if scope == "session":
+            clauses.append("session_id=?")
+            params.append(session_id)
+        with self.connection() as db:
+            row = db.execute(
+                f"SELECT * FROM usage_resets WHERE {' AND '.join(clauses)} "
+                "ORDER BY created_at DESC LIMIT 1", params,
+            ).fetchone()
+        return dict(row) if row else None
 
     def upsert_memory(self, content: str, *, kind: str = "episodic", status: str = "active",
                       confidence: float = 0.5, user_id: str = "local", workspace_id: str = "default",

--- a/main.py
+++ b/main.py
@@ -66,6 +66,7 @@ import re
 import subprocess
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar, copy_context
 from dataclasses import dataclass
 
 # macOS: suppress "MallocStackLogging: can't turn off malloc stack logging"
@@ -110,7 +111,7 @@ from providers import (
     ProviderConfig, LLMProvider, get_provider, detect_provider,
     save_provider_config, PROVIDER_DEFAULT_MODELS, PROVIDER_ENV_VARS,
     PROVIDER_FALLBACKS,
-    get_fallback_provider, get_cost_summary, reset_cost_tracker,
+    get_fallback_provider, get_cost_summary, reset_cost_tracker, usage_scope,
     save_provider_config_encrypted, encrypt_api_key, decrypt_api_key,
 )
 
@@ -506,6 +507,7 @@ _total_prompt_tokens: int = 0
 _total_completion_tokens: int = 0
 _last_prompt_tokens: int = 0
 _last_completion_tokens: int = 0
+_active_usage_run_id: ContextVar[str | None] = ContextVar("active_usage_run_id", default=None)
 _turn_cost_log: list[dict] = []  # {"tokens":int, "time":float, "tool_calls":int}
 
 def _track_tool_performance(action: str, result: str, elapsed: float) -> None:
@@ -2729,6 +2731,8 @@ def _finish_learning_run(run: dict[str, str], receipts: list[dict[str, Any]], ta
             source="acceptance_command",
         ))
     _last_learning_run = {"run": run, "receipts": receipts, "task": task}
+    if _active_usage_run_id.get() == run["run_id"]:
+        _active_usage_run_id.set(None)
     return _with_learning_notices(result)
 
 
@@ -3375,7 +3379,8 @@ def _bounded_provider_call(callback: Any) -> Any:
         except Exception as exc:
             outcome.put((False, exc))
 
-    threading.Thread(target=run, daemon=True).start()
+    context = copy_context()
+    threading.Thread(target=lambda: context.run(run), daemon=True).start()
     try:
         succeeded, value = outcome.get(timeout=_provider_timeout_seconds())
     except queue.Empty as exc:
@@ -3390,29 +3395,33 @@ def _get_llm_response(messages: list[dict[str, str]], model: str | None = None, 
     if llm_provider is None:
         return "[Error] LLM provider not initialised"
     try:
-        if stream and hasattr(llm_provider, 'chat_stream'):
-            # Streaming mode: collect chunks and print in real-time
-            collected: list[str] = []
-            for chunk in llm_provider.chat_stream(messages, model or DEEPSEEK_MODEL):
-                collected.append(chunk)
-                sys.stdout.write(chunk)
-                sys.stdout.flush()
-            text = "".join(collected).strip()
-            _last_prompt_tokens = 0
-            _last_completion_tokens = len(text) // 4  # rough estimate
-        else:
-            text, usage_dict = _bounded_provider_call(
-                lambda: llm_provider.chat(messages, model or DEEPSEEK_MODEL)
-            )
-            if usage_dict:
-                _last_prompt_tokens = usage_dict.get("prompt_tokens", 0)
-                _last_completion_tokens = usage_dict.get("completion_tokens", 0)
-                _total_prompt_tokens += _last_prompt_tokens
-                _total_completion_tokens += _last_completion_tokens
-            else:
+        with usage_scope(
+                store=memory_bank.store, user_id=memory_bank.user_id,
+                workspace_id=memory_bank.workspace_id, session_id=memory_bank.session_id,
+                run_id=_active_usage_run_id.get(), surface=_EXECUTION_SURFACE):
+            if stream and hasattr(llm_provider, 'chat_stream'):
+                # Streaming usage frames are persisted by the streaming implementation.
+                collected: list[str] = []
+                for chunk in llm_provider.chat_stream(messages, model or DEEPSEEK_MODEL):
+                    collected.append(chunk)
+                    sys.stdout.write(chunk)
+                    sys.stdout.flush()
+                text = "".join(collected).strip()
                 _last_prompt_tokens = 0
-                _last_completion_tokens = 0
-        return text
+                _last_completion_tokens = len(text) // 4  # presentation-only until a usage frame arrives
+            else:
+                text, usage_dict = _bounded_provider_call(
+                    lambda: llm_provider.chat(messages, model or DEEPSEEK_MODEL)
+                )
+                if usage_dict:
+                    _last_prompt_tokens = usage_dict.get("prompt_tokens", 0)
+                    _last_completion_tokens = usage_dict.get("completion_tokens", 0)
+                    _total_prompt_tokens += _last_prompt_tokens
+                    _total_completion_tokens += _last_completion_tokens
+                else:
+                    _last_prompt_tokens = 0
+                    _last_completion_tokens = 0
+            return text
     except TimeoutError as exc:
         return f"[LLM Error] {exc}"
     except Exception as e:
@@ -3801,6 +3810,7 @@ def _chat_turn_impl(user_input: str, clear_tasks: bool = False, profile: str | N
     DEEPSEEK_MODEL = _select_model(user_input)
     provider_model = f"{_provider_config.provider}:{DEEPSEEK_MODEL}" if _provider_config else f"unknown:{DEEPSEEK_MODEL}"
     learning_run = learning_engine.begin_run(resolved_profile, user_input, provider_model=provider_model)
+    _active_usage_run_id.set(learning_run["run_id"])
     learned_context, learning_receipts = learning_engine.artifact_context(learning_run)
     _execution_capability_token = issue_capability_token(
         f"surface:{_EXECUTION_SURFACE}",
@@ -5109,7 +5119,9 @@ def main() -> None:
     total_count = len(_SELF_LEARNING_FLAGS)
     console.print(f"[{_MUTED}]Self-learning:[/{_MUTED}] [{_ACCENT_DIM}]{enabled_count}/{total_count} features active (toggle with /self-learning)[/{_ACCENT_DIM}]")
     console.print(f"[{_MUTED}]Memory:[/{_MUTED}] [{_ACCENT_DIM}]SQLite v2 + rebuildable vector index — ask me what I remember[/{_ACCENT_DIM}]")
-    console.print(f"[{_MUTED}]Cost:[/{_MUTED}] [{_ACCENT_DIM}]{get_cost_summary()}[/{_ACCENT_DIM}]")
+    console.print(f"[{_MUTED}]Cost:[/{_MUTED}] [{_ACCENT_DIM}]{get_cost_summary(
+        store=memory_bank.store, user_id=memory_bank.user_id,
+        workspace_id=memory_bank.workspace_id)}[/{_ACCENT_DIM}]")
     # Horizontal rule
     console.print(f"[{_ACCENT_DIM}]{_BOX_H * 50}[/{_ACCENT_DIM}]")
 

--- a/providers.py
+++ b/providers.py
@@ -19,9 +19,15 @@ import os
 import sys
 import time
 import random
+import uuid
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import Any, Iterator
 from abc import ABC, abstractmethod
+
+from event_store import EventStore
 
 # ---------------------------------------------------------------------------
 # Provider metadata
@@ -70,42 +76,166 @@ PROVIDER_COSTS: dict[str, tuple[float, float]] = {
 }
 
 # ---------------------------------------------------------------------------
-# Global cost tracking
+# Durable usage ledger
 # ---------------------------------------------------------------------------
 
-_cost_tracker: dict[str, dict[str, int]] = {}  # {provider: {prompt_tokens, completion_tokens, cost_cents}}
+_PICOS_PER_DOLLAR = 10**12
+_TOKENS_PER_MILLION = 1_000_000
 
-def _track_cost(provider: str, usage: dict | None) -> None:
-    """Accumulate token usage and estimated cost for a provider."""
-    if usage is None:
-        return
-    entry = _cost_tracker.setdefault(provider, {"prompt_tokens": 0, "completion_tokens": 0, "cost_cents": 0})
-    pt = usage.get("prompt_tokens", 0) or 0
-    ct = usage.get("completion_tokens", 0) or 0
-    entry["prompt_tokens"] += pt
-    entry["completion_tokens"] += ct
-    costs = PROVIDER_COSTS.get(provider, (0, 0))
-    entry["cost_cents"] += int((pt * costs[0] + ct * costs[1]) / 10000)
 
-def get_cost_summary() -> str:
-    """Return a human-readable cost summary."""
-    if not _cost_tracker:
+@dataclass(frozen=True)
+class UsageScope:
+    store: EventStore
+    user_id: str = "local"
+    workspace_id: str = "default"
+    session_id: str | None = None
+    run_id: str | None = None
+    surface: str = "cli"
+
+
+_usage_scope: ContextVar[UsageScope | None] = ContextVar("usage_scope", default=None)
+
+
+@contextmanager
+def usage_scope(*, store: EventStore, user_id: str = "local", workspace_id: str = "default",
+                session_id: str | None = None, run_id: str | None = None,
+                surface: str | None = None) -> Iterator[None]:
+    """Attribute all provider calls in this execution context to one durable scope."""
+    token = _usage_scope.set(UsageScope(
+        store=store, user_id=user_id, workspace_id=workspace_id, session_id=session_id,
+        run_id=run_id, surface=surface or os.environ.get("KYROZEN_EXECUTION_SURFACE", "cli"),
+    ))
+    try:
+        yield
+    finally:
+        _usage_scope.reset(token)
+
+
+def _current_usage_scope() -> UsageScope:
+    return _usage_scope.get() or UsageScope(
+        EventStore(), surface=os.environ.get("KYROZEN_EXECUTION_SURFACE", "cli"),
+    )
+
+
+def _legacy_pricing_snapshot(provider: str) -> tuple[dict[str, Any], int, int]:
+    input_usd, output_usd = PROVIDER_COSTS.get(provider, (0.0, 0.0))
+    input_picos = int(Decimal(str(input_usd)) * _PICOS_PER_DOLLAR)
+    output_picos = int(Decimal(str(output_usd)) * _PICOS_PER_DOLLAR)
+    return {
+        "version": "legacy-provider-costs-v1",
+        "currency": "USD",
+        "input_picos_per_million": input_picos,
+        "output_picos_per_million": output_picos,
+    }, input_picos, output_picos
+
+
+def _usage_integer(usage: dict | None, key: str) -> int | None:
+    if usage is None or usage.get(key) is None:
+        return None
+    try:
+        return max(0, int(usage[key]))
+    except (TypeError, ValueError):
+        return None
+
+
+def _track_cost(provider: str, usage: dict | None, *, model: str = "unknown",
+                latency_ms: int | None = None, completion_state: str = "completed") -> str:
+    """Write one immutable provider attempt; summaries always read this ledger."""
+    scope = _current_usage_scope()
+    prompt_tokens = _usage_integer(usage, "prompt_tokens")
+    completion_tokens = _usage_integer(usage, "completion_tokens")
+    cache_hit_tokens = _usage_integer(usage, "cache_hit_tokens")
+    cache_miss_tokens = _usage_integer(usage, "cache_miss_tokens")
+    reasoning_tokens = _usage_integer(usage, "reasoning_tokens")
+    pricing_snapshot, input_rate, output_rate = _legacy_pricing_snapshot(provider)
+    cost_picos = None
+    if prompt_tokens is not None or completion_tokens is not None:
+        cost_picos = (
+            ((prompt_tokens or 0) * input_rate + (completion_tokens or 0) * output_rate)
+            // _TOKENS_PER_MILLION
+        )
+    attempt_id = f"usage_{uuid.uuid4().hex}"
+    scope.store.record_usage_attempt(
+        attempt_id=attempt_id, provider=provider, model=model, surface=scope.surface,
+        user_id=scope.user_id, workspace_id=scope.workspace_id, session_id=scope.session_id,
+        run_id=scope.run_id, cache_status="unknown", prompt_tokens=prompt_tokens,
+        cache_hit_tokens=cache_hit_tokens, cache_miss_tokens=cache_miss_tokens,
+        completion_tokens=completion_tokens, reasoning_tokens=reasoning_tokens,
+        latency_ms=latency_ms, completion_state=completion_state,
+        usage_status="authoritative" if usage is not None else "unknown",
+        cost_picos=cost_picos, pricing_snapshot=pricing_snapshot,
+    )
+    return attempt_id
+
+
+def _format_cost_picos(cost_picos: int) -> str:
+    if cost_picos <= 0:
+        return "$0"
+    cents = Decimal(cost_picos) / Decimal(_PICOS_PER_DOLLAR // 100)
+    if cents < 1:
+        return f"{cents.normalize():f}c"
+    dollars = Decimal(cost_picos) / _PICOS_PER_DOLLAR
+    return f"${dollars:.2f}"
+
+
+def _format_cost_summary(totals: dict[str, Any]) -> str:
+    if not totals["attempts"]:
         return "No usage yet"
-    parts = []
-    for prov, data in _cost_tracker.items():
-        cents = data["cost_cents"]
-        pt = data["prompt_tokens"]
-        ct = data["completion_tokens"]
-        if cents >= 100:
-            cost_str = f"${cents/100:.2f}"
-        else:
-            cost_str = f"{cents}c"
-        parts.append(f"{prov}: {pt/1000:.0f}K in / {ct/1000:.0f}K out ~{cost_str}")
-    return " | ".join(parts)
+    return " | ".join(
+        f"{item['provider']}: {item['prompt_tokens'] / 1000:.0f}K in / "
+        f"{item['completion_tokens'] / 1000:.0f}K out ~{_format_cost_picos(item['cost_picos'])}"
+        for item in totals["providers"]
+    )
 
-def reset_cost_tracker() -> None:
-    """Reset all cost tracking counters."""
-    _cost_tracker.clear()
+
+def _scope_totals(store: EventStore, *, scope: str, user_id: str, workspace_id: str,
+                  session_id: str | None = None) -> dict[str, Any]:
+    reset = None if scope == "installation" else store.latest_usage_reset(
+        scope=scope, user_id=user_id, workspace_id=workspace_id, session_id=session_id,
+    )
+    filters: dict[str, Any] = {"user_id": user_id}
+    if scope in {"workspace", "session"}:
+        filters["workspace_id"] = workspace_id
+    if scope == "session":
+        filters["session_id"] = session_id
+    totals = store.usage_totals(since=reset["created_at"] if reset else None, **filters)
+    totals["window_started_at"] = reset["created_at"] if reset else None
+    return totals
+
+
+def get_cost_report(*, store: EventStore | None = None, user_id: str = "local",
+                    workspace_id: str = "default", session_id: str | None = None,
+                    scope: str = "installation") -> dict[str, Any]:
+    """Return durable installation, workspace, and optional session usage windows."""
+    if scope not in {"installation", "workspace", "session"}:
+        raise ValueError("scope must be installation, workspace, or session")
+    if scope == "session" and not session_id:
+        raise ValueError("session scope requires a session_id")
+    store = store or EventStore()
+    totals = {
+        "installation": _scope_totals(store, scope="installation", user_id=user_id,
+                                       workspace_id=workspace_id),
+        "workspace": _scope_totals(store, scope="workspace", user_id=user_id,
+                                    workspace_id=workspace_id),
+        "session": (_scope_totals(store, scope="session", user_id=user_id,
+                                   workspace_id=workspace_id, session_id=session_id)
+                    if session_id else None),
+    }
+    return {"summary": _format_cost_summary(totals[scope]), "selected_scope": scope, "totals": totals}
+
+
+def get_cost_summary(**kwargs: Any) -> str:
+    """Return the legacy display string, reconstructed from durable attempts."""
+    return get_cost_report(**kwargs)["summary"]
+
+
+def reset_cost_tracker(*, store: EventStore | None = None, user_id: str = "local",
+                       workspace_id: str = "default", session_id: str | None = None,
+                       scope: str = "workspace") -> dict[str, str]:
+    """Create an audited reporting-window reset without deleting usage attempts."""
+    return (store or EventStore()).create_usage_reset(
+        scope=scope, user_id=user_id, workspace_id=workspace_id, session_id=session_id,
+    )
 
 # ---------------------------------------------------------------------------
 # Retry helper
@@ -208,6 +338,7 @@ class OpenAICompatProvider(LLMProvider):
 
     def chat(self, messages: list[dict[str, str]], model: str | None = None) -> tuple[str, dict | None]:
         model = model or self.config.model_simple
+        started = time.monotonic()
 
         def _call():
             response = self._client.chat.completions.create(model=model, messages=messages)
@@ -222,7 +353,8 @@ class OpenAICompatProvider(LLMProvider):
                 "prompt_tokens": usage.prompt_tokens or 0,
                 "completion_tokens": usage.completion_tokens or 0,
             }
-        _track_cost(self.config.provider, usage_dict)
+        _track_cost(self.config.provider, usage_dict, model=model,
+                    latency_ms=round((time.monotonic() - started) * 1000))
         return text.strip(), usage_dict
 
     def chat_stream(self, messages: list[dict[str, str]], model: str | None = None) -> Iterator[str]:
@@ -281,6 +413,7 @@ class AnthropicProvider(LLMProvider):
     def chat(self, messages: list[dict[str, str]], model: str | None = None) -> tuple[str, dict | None]:
         model = model or self.config.model_simple
         system_prompts, claude_messages = self._prepare_messages(messages)
+        started = time.monotonic()
 
         kwargs: dict[str, Any] = {
             "model": model,
@@ -305,7 +438,8 @@ class AnthropicProvider(LLMProvider):
                 "prompt_tokens": getattr(usage, "input_tokens", 0) or 0,
                 "completion_tokens": getattr(usage, "output_tokens", 0) or 0,
             }
-        _track_cost(self.config.provider, usage_dict)
+        _track_cost(self.config.provider, usage_dict, model=model,
+                    latency_ms=round((time.monotonic() - started) * 1000))
         return text.strip(), usage_dict
 
 # ---------------------------------------------------------------------------
@@ -329,6 +463,7 @@ class GoogleProvider(LLMProvider):
 
     def chat(self, messages: list[dict[str, str]], model: str | None = None) -> tuple[str, dict | None]:
         model = model or self.config.model_simple
+        started = time.monotonic()
 
         system_instruction: str | None = None
         history: list[dict] = []
@@ -379,7 +514,8 @@ class GoogleProvider(LLMProvider):
                 }
         except Exception:
             pass
-        _track_cost(self.config.provider, usage_dict)
+        _track_cost(self.config.provider, usage_dict, model=model,
+                    latency_ms=round((time.monotonic() - started) * 1000))
         return text.strip(), usage_dict
 
 # ---------------------------------------------------------------------------
@@ -402,6 +538,7 @@ class OllamaNativeProvider(LLMProvider):
         model = model or self.config.model_simple
         url = f"{self._base}/api/chat"
         payload = {"model": model, "messages": messages, "stream": False}
+        started = time.monotonic()
         try:
             resp = self._requests.post(url, json=payload, timeout=120)
             resp.raise_for_status()
@@ -411,7 +548,8 @@ class OllamaNativeProvider(LLMProvider):
                 "prompt_tokens": data.get("prompt_eval_count", 0) or 0,
                 "completion_tokens": data.get("eval_count", 0) or 0,
             }
-            _track_cost(self.config.provider, usage_dict)
+            _track_cost(self.config.provider, usage_dict, model=model,
+                        latency_ms=round((time.monotonic() - started) * 1000))
             return text.strip(), usage_dict
         except Exception as e:
             return f"[Ollama Error] {e}", None

--- a/server.py
+++ b/server.py
@@ -32,7 +32,7 @@ os.environ.setdefault("DEEPSEEK_API_KEY", os.environ.get("DEEPSEEK_API_KEY", "")
 os.environ.setdefault("KYROZEN_EXECUTION_SURFACE", "web")
 
 import main as _agent
-from providers import get_cost_summary, reset_cost_tracker
+from providers import get_cost_report, get_cost_summary, reset_cost_tracker
 from memory import MemoryBank
 from task_engine import TaskManager, TaskWorker
 from scheduler import JobScheduler
@@ -431,6 +431,20 @@ def _allowed_server_tools(surface: str) -> set[str]:
     capabilities = ",".join(sorted(_server_capabilities(surface)))
     return allowed_tool_names(_agent.AVAILABLE_TOOLS, capabilities)
 
+
+def _cost_summary() -> str:
+    return get_cost_summary(
+        store=_agent.memory_bank.store, user_id=_SERVER_ACTOR_ID,
+        workspace_id=_agent.memory_bank.workspace_id,
+    )
+
+
+def _cost_report(scope: str = "installation", session_id: str | None = None) -> dict[str, Any]:
+    return get_cost_report(
+        store=_agent.memory_bank.store, user_id=_SERVER_ACTOR_ID,
+        workspace_id=_agent.memory_bank.workspace_id, session_id=session_id, scope=scope,
+    )
+
 # ---------------------------------------------------------------------------
 # HTML Chat UI
 # ---------------------------------------------------------------------------
@@ -743,7 +757,7 @@ async def api_chat(request: Request):
     _emit_chat_completed(session, reply, streamed=False)
     _audit("REPLY", f"len={len(reply)}", session["user_id"])
     return {"reply": reply, "session_id": session_id, "profile": session["profile"],
-            "memory_receipt": session.get("last_memory_receipt"), "cost": get_cost_summary()}
+            "memory_receipt": session.get("last_memory_receipt"), "cost": _cost_summary()}
 
 
 @app.post("/api/chat/stream", dependencies=[Depends(require_api_access)])
@@ -776,7 +790,7 @@ async def api_chat_stream(request: Request):
                 chunk = reply[i:i+chunk_size]
                 yield f"data: {json.dumps({'chunk': chunk})}\n\n"
                 await asyncio_sleep(0.01)
-            yield f"data: {json.dumps({'cost': get_cost_summary()})}\n\n"
+            yield f"data: {json.dumps({'cost': _cost_summary()})}\n\n"
             if session.get("last_memory_receipt"):
                 yield f"data: {json.dumps({'memory_receipt': session['last_memory_receipt']})}\n\n"
             yield "data: [DONE]\n\n"
@@ -1165,9 +1179,37 @@ async def api_v2_run_agent(request: Request):
 
 
 @app.get("/api/cost", dependencies=[Depends(require_api_access)])
-async def api_cost():
-    """Get cost summary."""
-    return {"summary": get_cost_summary()}
+async def api_cost(scope: str = "installation", session_id: str | None = None):
+    """Get durable installation, workspace, or session usage totals."""
+    if scope not in {"installation", "workspace", "session"}:
+        raise HTTPException(400, "scope must be installation, workspace, or session")
+    session = _normalise_session_id(session_id) if session_id else None
+    if scope == "session" and not session:
+        raise HTTPException(400, "session_id is required for session scope")
+    return _cost_report(scope, session)
+
+
+@app.post("/api/cost/reset", dependencies=[Depends(require_api_access)])
+async def api_cost_reset(request: Request):
+    """Start a new durable workspace/session reporting window without deleting usage."""
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(400, "Invalid JSON")
+    if not isinstance(body, dict) or body.get("confirm") != "reset-cost":
+        raise HTTPException(400, "Set confirm to reset-cost to reset a usage window")
+    scope = str(body.get("scope", "workspace"))
+    if scope not in {"workspace", "session"}:
+        raise HTTPException(400, "scope must be workspace or session")
+    session_id = _normalise_session_id(body.get("session_id")) if body.get("session_id") else None
+    if scope == "session" and not session_id:
+        raise HTTPException(400, "session_id is required for session scope")
+    reset = reset_cost_tracker(
+        store=_agent.memory_bank.store, user_id=_SERVER_ACTOR_ID,
+        workspace_id=_agent.memory_bank.workspace_id, session_id=session_id, scope=scope,
+    )
+    _audit("USAGE_RESET", f"scope={scope}", _SERVER_ACTOR_ID)
+    return {"reset": reset, **_cost_report(scope, session_id)}
 
 
 @app.get("/api/health", dependencies=[Depends(require_api_access)])

--- a/tests/test_usage_ledger.py
+++ b/tests/test_usage_ledger.py
@@ -1,0 +1,128 @@
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+from event_store import EventStore
+from fastapi.testclient import TestClient
+from memory import MemoryBank
+from providers import PROVIDER_COSTS, _track_cost, usage_scope
+import server
+
+
+class UsageLedgerTests(unittest.TestCase):
+    @staticmethod
+    def _record(store: EventStore, *, workspace: str = "project", session: str | None = "session") -> None:
+        with usage_scope(
+            store=store, user_id="local", workspace_id=workspace, session_id=session,
+            run_id="run-1", surface="cli",
+        ):
+            _track_cost("deepseek", {"prompt_tokens": 1100, "completion_tokens": 50},
+                        model="deepseek-chat", latency_ms=25)
+
+    def test_server_cost_api_reconstructs_usage_after_process_restart(self):
+        repository = Path(__file__).parents[1]
+        script = (
+            "import json; from fastapi.testclient import TestClient; import server; "
+            "print(json.dumps(TestClient(server.app).get('/api/cost').json()))"
+        )
+        with tempfile.TemporaryDirectory(prefix="openkyrozen-usage-restart-") as directory:
+            root = Path(directory)
+            home = root / "home"
+            home.mkdir()
+            database = root / "state.sqlite3"
+            self._record(EventStore(database), workspace="default")
+            environment = os.environ.copy()
+            environment.update({
+                "HOME": str(home), "KYROZEN_DB_PATH": str(database),
+                "KYROZEN_DISABLE_VECTOR_INDEX": "1", "KYROZEN_PROVIDER": "ollama",
+                "PYTHONPATH": str(repository),
+            })
+            environment.pop("KYROZEN_SERVER_TOKEN", None)
+            reports = []
+            for _ in range(2):
+                result = subprocess.run(
+                    [sys.executable, "-c", script], cwd=root, env=environment,
+                    capture_output=True, text=True, timeout=30,
+                )
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                reports.append(json.loads(result.stdout.strip().splitlines()[-1]))
+            self.assertEqual(reports[0]["summary"], reports[1]["summary"])
+            self.assertEqual(reports[1]["totals"]["installation"]["prompt_tokens"], 1100)
+            self.assertEqual(reports[1]["totals"]["workspace"]["completion_tokens"], 50)
+
+    def test_concurrent_attempts_keep_unique_ids_and_pricing_snapshots(self):
+        with tempfile.TemporaryDirectory(prefix="openkyrozen-usage-concurrent-") as directory:
+            store = EventStore(Path(directory) / "state.sqlite3")
+
+            def record(index: int) -> None:
+                with usage_scope(store=store, workspace_id="project", session_id=f"session-{index % 2}",
+                                 run_id=f"run-{index}", surface="mcp"):
+                    _track_cost("deepseek", {"prompt_tokens": 1, "completion_tokens": 2},
+                                model="deepseek-chat", latency_ms=index)
+
+            threads = [threading.Thread(target=record, args=(index,)) for index in range(32)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+
+            attempts = store.list_usage_attempts(workspace_id="project", user_id="local")
+            totals = store.usage_totals(workspace_id="project", user_id="local")
+            self.assertEqual(len(attempts), 32)
+            self.assertEqual(len({item["id"] for item in attempts}), 32)
+            self.assertEqual(totals["prompt_tokens"], 32)
+            self.assertEqual(totals["completion_tokens"], 64)
+            self.assertTrue(all(item["pricing_snapshot"]["version"] == "legacy-provider-costs-v1"
+                                for item in attempts))
+            self.assertEqual(
+                {item["model"] for item in attempts}, {"deepseek-chat"},
+            )
+            self.assertEqual(
+                {item["surface"] for item in attempts}, {"mcp"},
+            )
+            self.assertEqual(
+                {item["session_id"] for item in attempts}, {"session-0", "session-1"},
+            )
+            self.assertEqual({item["run_id"] for item in attempts}, {f"run-{index}" for index in range(32)})
+            self.assertTrue(all(item["usage_status"] == "authoritative" for item in attempts))
+            self.assertTrue(all(item["completion_state"] == "completed" for item in attempts))
+            original_cost = totals["cost_picos"]
+            previous_rates = PROVIDER_COSTS["deepseek"]
+            try:
+                PROVIDER_COSTS["deepseek"] = (999.0, 999.0)
+                self.assertEqual(
+                    store.usage_totals(workspace_id="project", user_id="local")["cost_picos"],
+                    original_cost,
+                )
+            finally:
+                PROVIDER_COSTS["deepseek"] = previous_rates
+
+    def test_reset_requires_explicit_confirmation_and_preserves_installation_ledger(self):
+        with tempfile.TemporaryDirectory(prefix="openkyrozen-usage-reset-") as directory:
+            memory = MemoryBank(Path(directory) / "state.sqlite3", workspace_id="project")
+            self._record(memory.store)
+            original_memory = server._agent.memory_bank
+            server._agent.memory_bank = memory
+            try:
+                client = TestClient(server.app)
+                self.assertEqual(client.post("/api/cost/reset", json={"scope": "workspace"}).status_code, 400)
+                reset = client.post("/api/cost/reset", json={
+                    "scope": "workspace", "confirm": "reset-cost",
+                })
+                self.assertEqual(reset.status_code, 200, reset.text)
+                self.assertEqual(reset.json()["totals"]["workspace"]["attempts"], 0)
+                self.assertEqual(reset.json()["totals"]["installation"]["attempts"], 1)
+                self.assertTrue(memory.store.list_events(
+                    "usage.reset", workspace_id="project", user_id=server._SERVER_ACTOR_ID,
+                ))
+            finally:
+                server._agent.memory_bank = original_memory
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace process-local cost counters with an immutable SQLite usage-attempt ledger
- reconstruct installation, workspace, and session totals through `/api/cost`, with an explicitly confirmed, audited reporting-window reset
- preserve legacy `summary` output while recording provider/model/surface/session/run attribution, latency, usage state, and the applied pricing snapshot

## Validation
- `python -m unittest discover -s tests -p 'test_usage_ledger.py' -v`\n- `make check`\n- `make lint`\n- `make docs-check`\n- `make test` (154 passed, including browser flow)\n- `make test-core` (154 passed, 2 browser-only skips)\n- `git diff --check`\n\nFixes #85