### PR TITLE
fix: aggregate ledger costs before rounding

### DIFF
--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **154 unittest cases**.
+Current repository test count at this snapshot: **155 unittest cases**.
 
 ## Verified surface
 

--- a/event_store.py
+++ b/event_store.py
@@ -373,6 +373,15 @@ class EventStore:
                 f"SELECT provider, {columns} FROM usage_attempts WHERE {' AND '.join(clauses)} "
                 "GROUP BY provider ORDER BY provider", params,
             ).fetchall()
+            pricing_groups = db.execute(
+                "SELECT provider, pricing_snapshot, "
+                "SUM(COALESCE(prompt_tokens, 0)) AS prompt_tokens, "
+                "SUM(COALESCE(completion_tokens, 0)) AS completion_tokens, "
+                "SUM(COALESCE(cost_picos, 0)) AS cost_picos "
+                f"FROM usage_attempts WHERE {' AND '.join(clauses)} "
+                "GROUP BY provider, pricing_snapshot",
+                params,
+            ).fetchall()
 
         def normalise(row: sqlite3.Row | None) -> dict[str, int]:
             names = ("attempts", "authoritative_attempts", "estimated_attempts", "prompt_tokens",
@@ -384,9 +393,33 @@ class EventStore:
             )
             return values
 
+        def exact_cost(groups: list[sqlite3.Row]) -> int:
+            """Round once after combining frozen per-million pricing numerators."""
+            numerator = fallback = 0
+            for row in groups:
+                snapshot = self._loads(row["pricing_snapshot"], {})
+                try:
+                    input_rate = max(0, int(snapshot["input_picos_per_million"]))
+                    output_rate = max(0, int(snapshot["output_picos_per_million"]))
+                except (KeyError, TypeError, ValueError):
+                    # Compatibility for any manually-created legacy ledger row.
+                    fallback += int(row["cost_picos"] or 0)
+                    continue
+                numerator += (int(row["prompt_tokens"] or 0) * input_rate
+                              + int(row["completion_tokens"] or 0) * output_rate)
+            return fallback + numerator // 1_000_000
+
+        totals = normalise(total)
+        totals["cost_picos"] = exact_cost(pricing_groups)
+        provider_groups: dict[str, list[sqlite3.Row]] = {}
+        for row in pricing_groups:
+            provider_groups.setdefault(row["provider"], []).append(row)
+
         return {
-            **normalise(total), "currency": "USD",
-            "providers": [dict(provider=row["provider"], **normalise(row)) for row in by_provider],
+            **totals, "currency": "USD",
+            "providers": [dict(provider=row["provider"], **{
+                **normalise(row), "cost_picos": exact_cost(provider_groups[row["provider"]]),
+            }) for row in by_provider],
         }
 
     def create_usage_reset(

--- a/tests/test_usage_ledger.py
+++ b/tests/test_usage_ledger.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from event_store import EventStore
 from fastapi.testclient import TestClient
 from memory import MemoryBank
-from providers import PROVIDER_COSTS, _track_cost, usage_scope
+from providers import PROVIDER_COSTS, _track_cost, get_cost_summary, usage_scope
 import server
 
 
@@ -122,6 +122,41 @@ class UsageLedgerTests(unittest.TestCase):
                 ))
             finally:
                 server._agent.memory_bank = original_memory
+
+    def test_short_and_mixed_calls_aggregate_before_display_rounding(self):
+        with tempfile.TemporaryDirectory(prefix="openkyrozen-usage-precision-") as directory:
+            store = EventStore(Path(directory) / "state.sqlite3")
+            with usage_scope(store=store, workspace_id="project", session_id="short"):
+                for _ in range(1000):
+                    _track_cost("deepseek", {"prompt_tokens": 0, "completion_tokens": 100},
+                                model="deepseek-chat")
+            with usage_scope(store=store, workspace_id="project", session_id="mixed"):
+                for _ in range(1000):
+                    _track_cost("deepseek", {"prompt_tokens": 100, "completion_tokens": 100},
+                                model="deepseek-chat")
+            with usage_scope(store=store, workspace_id="project", session_id="combined-short"):
+                _track_cost("deepseek", {"prompt_tokens": 0, "completion_tokens": 100_000},
+                            model="deepseek-chat")
+            with usage_scope(store=store, workspace_id="project", session_id="combined-mixed"):
+                _track_cost("deepseek", {"prompt_tokens": 100_000, "completion_tokens": 100_000},
+                            model="deepseek-chat")
+
+            short = store.usage_totals(workspace_id="project", session_id="short", user_id="local")
+            mixed = store.usage_totals(workspace_id="project", session_id="mixed", user_id="local")
+            combined_short = store.usage_totals(
+                workspace_id="project", session_id="combined-short", user_id="local",
+            )
+            combined_mixed = store.usage_totals(
+                workspace_id="project", session_id="combined-mixed", user_id="local",
+            )
+            self.assertEqual(short["cost_picos"], 110_000_000_000)
+            self.assertEqual(mixed["cost_picos"], 137_000_000_000)
+            self.assertEqual(short["cost_picos"], combined_short["cost_picos"])
+            self.assertEqual(mixed["cost_picos"], combined_mixed["cost_picos"])
+            self.assertEqual(
+                get_cost_summary(store=store, workspace_id="project", session_id="short", scope="session"),
+                "deepseek: 0K in / 100K out ~$0.11",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- aggregate frozen per-million pricing numerators from the SQLite ledger before converting to the stored sub-cent unit
- preserve immutable per-attempt pricing snapshots while avoiding request-boundary precision loss
- add short-call and mixed-usage regression coverage

## Validation
- `python -m unittest discover -s tests -p 'test_usage_ledger.py' -v`\n- `make check`\n- `make lint`\n- `make docs-check`\n- `make test` (155 passed, including browser flow)\n- `git diff --check`\n\nFixes #78