### PR TITLE
fix: apply DeepSeek V4 pricing

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -79,7 +79,7 @@ OpenKyrozen はターミナルで動作する**自己学習型 AI エージェ�
 
 | プロバイダー | キーの取得 | コスト |
 |-------------|-----------|------|
-| **DeepSeek** | [platform.deepseek.com](https://platform.deepseek.com) | ~$0.27/100万入力トークン |
+| **DeepSeek** | [platform.deepseek.com](https://platform.deepseek.com) | [V4 のピーク/オフピーク・キャッシュ対応料金](https://api-docs.deepseek.com/quick_start/pricing/) |
 | **OpenAI** | [platform.openai.com](https://platform.openai.com) | ~$2.50/100万入力トークン |
 | **Anthropic (Claude)** | [console.anthropic.com](https://console.anthropic.com) | ~$3.00/100万入力トークン |
 | **Google (Gemini)** | [aistudio.google.com](https://aistudio.google.com) | ~$0.15/100万入力トークン |
@@ -250,8 +250,8 @@ Kyrozen はすべてのリクエストを自動分類し、動作を適応させ
 エージェントは簡単なタスクと複雑なタスクで異なるモデルを選択します。これらは上書き可能です：
 
 ```bash
-export KYROZEN_MODEL_SIMPLE=deepseek-chat
-export KYROZEN_MODEL_COMPLEX=deepseek-reasoner
+export KYROZEN_MODEL_SIMPLE=deepseek-v4-flash
+export KYROZEN_MODEL_COMPLEX=deepseek-v4-pro
 ```
 
 | プロバイダー | 簡単なタスク（デフォルト） | 複雑なタスク（デフォルト） |

--- a/README.ko.md
+++ b/README.ko.md
@@ -79,7 +79,7 @@ OpenKyrozen은 터미널에서 실행되는 **자기 학습형 AI 에이전트**
 
 | 제공자 | 키 발급 | 비용 |
 |--------|--------|------|
-| **DeepSeek** | [platform.deepseek.com](https://platform.deepseek.com) | ~$0.27/100만 입력 토큰 |
+| **DeepSeek** | [platform.deepseek.com](https://platform.deepseek.com) | [V4 피크/비피크, 캐시 인식 가격](https://api-docs.deepseek.com/quick_start/pricing/) |
 | **OpenAI** | [platform.openai.com](https://platform.openai.com) | ~$2.50/100만 입력 토큰 |
 | **Anthropic (Claude)** | [console.anthropic.com](https://console.anthropic.com) | ~$3.00/100만 입력 토큰 |
 | **Google (Gemini)** | [aistudio.google.com](https://aistudio.google.com) | ~$0.15/100만 입력 토큰 |
@@ -250,8 +250,8 @@ Kyrozen은 모든 요청을 자동 분류하고 동작을 조정합니다:
 에이전트는 간단한 작업과 복잡한 작업에 서로 다른 모델을 선택합니다. 재정의할 수 있습니다:
 
 ```bash
-export KYROZEN_MODEL_SIMPLE=deepseek-chat
-export KYROZEN_MODEL_COMPLEX=deepseek-reasoner
+export KYROZEN_MODEL_SIMPLE=deepseek-v4-flash
+export KYROZEN_MODEL_COMPLEX=deepseek-v4-pro
 ```
 
 | 제공자 | 간단한 작업 (기본값) | 복잡한 작업 (기본값) |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Think of it as an AI teammate that gets smarter every time you use it.
 
 | Provider | Get a key | Cost |
 |----------|-----------|------|
-| **DeepSeek** | [platform.deepseek.com](https://platform.deepseek.com) | ~$0.27/M input tokens |
+| **DeepSeek** | [platform.deepseek.com](https://platform.deepseek.com) | [V4 peak/off-peak, cache-aware pricing](https://api-docs.deepseek.com/quick_start/pricing/) |
 | **OpenAI** | [platform.openai.com](https://platform.openai.com) | ~$2.50/M input tokens |
 | **Anthropic (Claude)** | [console.anthropic.com](https://console.anthropic.com) | ~$3.00/M input tokens |
 | **Google (Gemini)** | [aistudio.google.com](https://aistudio.google.com) | ~$0.15/M input tokens |
@@ -260,13 +260,13 @@ Kyrozen automatically classifies every request and adapts its behavior:
 The agent picks different models for simple vs complex tasks. You can override these:
 
 ```bash
-export KYROZEN_MODEL_SIMPLE=deepseek-chat
-export KYROZEN_MODEL_COMPLEX=deepseek-reasoner
+export KYROZEN_MODEL_SIMPLE=deepseek-v4-flash
+export KYROZEN_MODEL_COMPLEX=deepseek-v4-pro
 ```
 
 | Provider | Simple tasks (default) | Complex tasks (default) |
 |----------|----------------------|------------------------|
-| DeepSeek | `deepseek-chat` | `deepseek-reasoner` |
+| DeepSeek | `deepseek-v4-flash` | `deepseek-v4-pro` |
 | OpenAI | `gpt-4o` | `gpt-4o` |
 | Anthropic | `claude-sonnet-4-20250514` | `claude-sonnet-4-20250514` |
 | Google | `gemini-2.5-flash` | `gemini-2.5-pro` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,7 +79,7 @@ OpenKyrozen 是一款在终端中运行的**自学习 AI 智能体**。与普通
 
 | 服务商 | 获取密钥 | 费用 |
 |--------|---------|------|
-| **DeepSeek** | [platform.deepseek.com](https://platform.deepseek.com) | ~$0.27/百万输入 token |
+| **DeepSeek** | [platform.deepseek.com](https://platform.deepseek.com) | [V4 高峰/低峰、缓存感知计费](https://api-docs.deepseek.com/quick_start/pricing/) |
 | **OpenAI** | [platform.openai.com](https://platform.openai.com) | ~$2.50/百万输入 token |
 | **Anthropic (Claude)** | [console.anthropic.com](https://console.anthropic.com) | ~$3.00/百万输入 token |
 | **Google (Gemini)** | [aistudio.google.com](https://aistudio.google.com) | ~$0.15/百万输入 token |
@@ -246,8 +246,8 @@ Kyrozen 自动对每个请求进行分类并调整行为：
 智能体针对简单任务和复杂任务选择不同模型。你可以覆盖这些默认值：
 
 ```bash
-export KYROZEN_MODEL_SIMPLE=deepseek-chat
-export KYROZEN_MODEL_COMPLEX=deepseek-reasoner
+export KYROZEN_MODEL_SIMPLE=deepseek-v4-flash
+export KYROZEN_MODEL_COMPLEX=deepseek-v4-pro
 ```
 
 | 服务商 | 简单任务（默认） | 复杂任务（默认） |

--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **155 unittest cases**.
+Current repository test count at this snapshot: **157 unittest cases**.
 
 ## Verified surface
 

--- a/event_store.py
+++ b/event_store.py
@@ -376,6 +376,8 @@ class EventStore:
             pricing_groups = db.execute(
                 "SELECT provider, pricing_snapshot, "
                 "SUM(COALESCE(prompt_tokens, 0)) AS prompt_tokens, "
+                "SUM(COALESCE(cache_hit_tokens, 0)) AS cache_hit_tokens, "
+                "SUM(COALESCE(cache_miss_tokens, 0)) AS cache_miss_tokens, "
                 "SUM(COALESCE(completion_tokens, 0)) AS completion_tokens, "
                 "SUM(COALESCE(cost_picos, 0)) AS cost_picos "
                 f"FROM usage_attempts WHERE {' AND '.join(clauses)} "
@@ -399,14 +401,23 @@ class EventStore:
             for row in groups:
                 snapshot = self._loads(row["pricing_snapshot"], {})
                 try:
-                    input_rate = max(0, int(snapshot["input_picos_per_million"]))
                     output_rate = max(0, int(snapshot["output_picos_per_million"]))
+                    cache_miss_rate = snapshot.get("cache_miss_picos_per_million")
+                    input_rate = max(0, int(
+                        cache_miss_rate if cache_miss_rate is not None else snapshot["input_picos_per_million"],
+                    ))
                 except (KeyError, TypeError, ValueError):
                     # Compatibility for any manually-created legacy ledger row.
                     fallback += int(row["cost_picos"] or 0)
                     continue
-                numerator += (int(row["prompt_tokens"] or 0) * input_rate
-                              + int(row["completion_tokens"] or 0) * output_rate)
+                prompt = int(row["prompt_tokens"] or 0)
+                if "cache_hit_picos_per_million" in snapshot:
+                    hit = min(prompt, max(0, int(row["cache_hit_tokens"] or 0)))
+                    numerator += (hit * max(0, int(snapshot["cache_hit_picos_per_million"]))
+                                  + (prompt - hit) * input_rate)
+                else:
+                    numerator += prompt * input_rate
+                numerator += int(row["completion_tokens"] or 0) * output_rate
             return fallback + numerator // 1_000_000
 
         totals = normalise(total)

--- a/main.py
+++ b/main.py
@@ -338,9 +338,9 @@ _provider_config: ProviderConfig | None = None
 llm_provider: LLMProvider | None = None
 
 # Backward-compatible aliases (used throughout the codebase)
-DEEPSEEK_MODEL_SIMPLE = "deepseek-chat"   # set at init time from provider
-DEEPSEEK_MODEL_COMPLEX = "deepseek-reasoner"
-MODEL_NAME = "deepseek-chat (V4 auto-select)"  # updated at init
+DEEPSEEK_MODEL_SIMPLE = "deepseek-v4-flash"   # set at init time from provider
+DEEPSEEK_MODEL_COMPLEX = "deepseek-v4-pro"
+MODEL_NAME = "deepseek-v4-flash"  # updated at init
 # -------- Self-learning feature flags (toggled via /self-learning) --------
 # Keep this list as the public feature contract.  The dispatcher below binds
 # each name to exactly one bounded executor and both CLI and Web use it.

--- a/providers.py
+++ b/providers.py
@@ -23,6 +23,7 @@ import uuid
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any, Iterator
 from abc import ABC, abstractmethod
@@ -34,7 +35,7 @@ from event_store import EventStore
 # ---------------------------------------------------------------------------
 
 PROVIDER_DEFAULT_MODELS: dict[str, tuple[str, str]] = {
-    "deepseek":  ("deepseek-chat",     "deepseek-reasoner"),
+    "deepseek":  ("deepseek-v4-flash", "deepseek-v4-pro"),
     "openai":    ("gpt-4o",             "gpt-4o"),
     "anthropic": ("claude-sonnet-4-20250514", "claude-sonnet-4-20250514"),
     "google":    ("gemini-2.5-flash",   "gemini-2.5-pro"),
@@ -81,6 +82,16 @@ PROVIDER_COSTS: dict[str, tuple[float, float]] = {
 
 _PICOS_PER_DOLLAR = 10**12
 _TOKENS_PER_MILLION = 1_000_000
+_DEEPSEEK_V4_EFFECTIVE_AT = datetime(2026, 8, 16, 16, tzinfo=timezone.utc)
+_DEEPSEEK_V4_MODELS = {
+    "deepseek-v4-flash": ("0.014", "0.44", "1.32"),
+    "deepseek-v4-flash-vision-exp": ("0.014", "0.44", "1.32"),
+    "deepseek-v4-pro": ("0.044", "1.32", "3.96"),
+}
+_DEEPSEEK_V4_ALIASES = {
+    "deepseek-chat": "deepseek-v4-flash",
+    "deepseek-reasoner": "deepseek-v4-flash",
+}
 
 
 @dataclass(frozen=True)
@@ -129,6 +140,35 @@ def _legacy_pricing_snapshot(provider: str) -> tuple[dict[str, Any], int, int]:
     }, input_picos, output_picos
 
 
+def _deepseek_v4_pricing_snapshot(model: str, occurred_at: datetime) -> tuple[dict[str, Any] | None, bool]:
+    """Freeze the official DeepSeek V4 rate card selected at a UTC timestamp."""
+    canonical_model = _DEEPSEEK_V4_ALIASES.get(model.strip().lower(), model.strip().lower())
+    rates = _DEEPSEEK_V4_MODELS.get(canonical_model)
+    if rates is None:
+        return None, False
+    instant = occurred_at.astimezone(timezone.utc)
+    peak = instant.weekday() < 5 and (1 <= instant.hour < 4 or 6 <= instant.hour < 10)
+    multiplier = 1 if peak else 0.5
+    hit, miss, output = (
+        int(Decimal(rate) * Decimal(str(multiplier)) * _PICOS_PER_DOLLAR)
+        for rate in rates
+    )
+    current_schedule = instant >= _DEEPSEEK_V4_EFFECTIVE_AT
+    return {
+        "version": "deepseek-v4-pricing-2026-08-16",
+        "source": "https://api-docs.deepseek.com/quick_start/pricing/",
+        "currency": "USD",
+        "model": canonical_model,
+        "priced_at": instant.isoformat(),
+        "effective_at": _DEEPSEEK_V4_EFFECTIVE_AT.isoformat(),
+        "billing_window": "peak" if peak else "off_peak",
+        "cache_hit_picos_per_million": hit,
+        "cache_miss_picos_per_million": miss,
+        "output_picos_per_million": output,
+        "pricing_status": "authoritative" if current_schedule else "estimated_current_schedule",
+    }, current_schedule
+
+
 def _usage_integer(usage: dict | None, key: str) -> int | None:
     if usage is None or usage.get(key) is None:
         return None
@@ -139,30 +179,61 @@ def _usage_integer(usage: dict | None, key: str) -> int | None:
 
 
 def _track_cost(provider: str, usage: dict | None, *, model: str = "unknown",
-                latency_ms: int | None = None, completion_state: str = "completed") -> str:
+                latency_ms: int | None = None, completion_state: str = "completed",
+                occurred_at: datetime | None = None) -> str:
     """Write one immutable provider attempt; summaries always read this ledger."""
     scope = _current_usage_scope()
     prompt_tokens = _usage_integer(usage, "prompt_tokens")
     completion_tokens = _usage_integer(usage, "completion_tokens")
     cache_hit_tokens = _usage_integer(usage, "cache_hit_tokens")
     cache_miss_tokens = _usage_integer(usage, "cache_miss_tokens")
+    if cache_hit_tokens is None:
+        cache_hit_tokens = _usage_integer(usage, "prompt_cache_hit_tokens")
+    if cache_miss_tokens is None:
+        cache_miss_tokens = _usage_integer(usage, "prompt_cache_miss_tokens")
     reasoning_tokens = _usage_integer(usage, "reasoning_tokens")
-    pricing_snapshot, input_rate, output_rate = _legacy_pricing_snapshot(provider)
+    pricing_snapshot = None
+    current_schedule = True
+    if provider == "deepseek":
+        pricing_snapshot, current_schedule = _deepseek_v4_pricing_snapshot(
+            model, occurred_at or datetime.now(timezone.utc),
+        )
+    if pricing_snapshot is None:
+        pricing_snapshot, input_rate, output_rate = _legacy_pricing_snapshot(provider)
+    else:
+        input_rate = int(pricing_snapshot["cache_miss_picos_per_million"])
+        output_rate = int(pricing_snapshot["output_picos_per_million"])
     cost_picos = None
     if prompt_tokens is not None or completion_tokens is not None:
-        cost_picos = (
-            ((prompt_tokens or 0) * input_rate + (completion_tokens or 0) * output_rate)
-            // _TOKENS_PER_MILLION
-        )
+        prompt = prompt_tokens or 0
+        if "cache_hit_picos_per_million" in pricing_snapshot:
+            hit = min(prompt, cache_hit_tokens or 0)
+            input_cost = (hit * int(pricing_snapshot["cache_hit_picos_per_million"])
+                          + (prompt - hit) * input_rate)
+        else:
+            input_cost = prompt * input_rate
+        cost_picos = (input_cost + (completion_tokens or 0) * output_rate) // _TOKENS_PER_MILLION
+    if cache_hit_tokens is None and cache_miss_tokens is None:
+        cache_status = "unknown"
+    elif (cache_hit_tokens or 0) and (cache_miss_tokens or 0):
+        cache_status = "mixed"
+    elif cache_hit_tokens:
+        cache_status = "hit"
+    else:
+        cache_status = "miss"
+    usage_status = "unknown" if usage is None else (
+        "authoritative" if current_schedule and (provider != "deepseek" or cache_status != "unknown")
+        else "estimated"
+    )
     attempt_id = f"usage_{uuid.uuid4().hex}"
     scope.store.record_usage_attempt(
         attempt_id=attempt_id, provider=provider, model=model, surface=scope.surface,
         user_id=scope.user_id, workspace_id=scope.workspace_id, session_id=scope.session_id,
-        run_id=scope.run_id, cache_status="unknown", prompt_tokens=prompt_tokens,
+        run_id=scope.run_id, cache_status=cache_status, prompt_tokens=prompt_tokens,
         cache_hit_tokens=cache_hit_tokens, cache_miss_tokens=cache_miss_tokens,
         completion_tokens=completion_tokens, reasoning_tokens=reasoning_tokens,
         latency_ms=latency_ms, completion_state=completion_state,
-        usage_status="authoritative" if usage is not None else "unknown",
+        usage_status=usage_status,
         cost_picos=cost_picos, pricing_snapshot=pricing_snapshot,
     )
     return attempt_id
@@ -349,9 +420,13 @@ class OpenAICompatProvider(LLMProvider):
         usage = getattr(response, "usage", None)
         usage_dict = None
         if usage is not None:
+            completion_details = getattr(usage, "completion_tokens_details", None)
             usage_dict = {
                 "prompt_tokens": usage.prompt_tokens or 0,
                 "completion_tokens": usage.completion_tokens or 0,
+                "prompt_cache_hit_tokens": getattr(usage, "prompt_cache_hit_tokens", None),
+                "prompt_cache_miss_tokens": getattr(usage, "prompt_cache_miss_tokens", None),
+                "reasoning_tokens": getattr(completion_details, "reasoning_tokens", None),
             }
         _track_cost(self.config.provider, usage_dict, model=model,
                     latency_ms=round((time.monotonic() - started) * 1000))

--- a/tests/test_usage_ledger.py
+++ b/tests/test_usage_ledger.py
@@ -5,12 +5,14 @@ import sys
 import tempfile
 import threading
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 
 from event_store import EventStore
 from fastapi.testclient import TestClient
 from memory import MemoryBank
-from providers import PROVIDER_COSTS, _track_cost, get_cost_summary, usage_scope
+from providers import OpenAICompatProvider, ProviderConfig, _track_cost, get_cost_summary, usage_scope
 import server
 
 
@@ -62,7 +64,10 @@ class UsageLedgerTests(unittest.TestCase):
             def record(index: int) -> None:
                 with usage_scope(store=store, workspace_id="project", session_id=f"session-{index % 2}",
                                  run_id=f"run-{index}", surface="mcp"):
-                    _track_cost("deepseek", {"prompt_tokens": 1, "completion_tokens": 2},
+                    _track_cost("deepseek", {
+                        "prompt_tokens": 1, "prompt_cache_hit_tokens": 0,
+                        "prompt_cache_miss_tokens": 1, "completion_tokens": 2,
+                    },
                                 model="deepseek-chat", latency_ms=index)
 
             threads = [threading.Thread(target=record, args=(index,)) for index in range(32)]
@@ -77,7 +82,7 @@ class UsageLedgerTests(unittest.TestCase):
             self.assertEqual(len({item["id"] for item in attempts}), 32)
             self.assertEqual(totals["prompt_tokens"], 32)
             self.assertEqual(totals["completion_tokens"], 64)
-            self.assertTrue(all(item["pricing_snapshot"]["version"] == "legacy-provider-costs-v1"
+            self.assertTrue(all(item["pricing_snapshot"]["version"] == "deepseek-v4-pricing-2026-08-16"
                                 for item in attempts))
             self.assertEqual(
                 {item["model"] for item in attempts}, {"deepseek-chat"},
@@ -91,16 +96,6 @@ class UsageLedgerTests(unittest.TestCase):
             self.assertEqual({item["run_id"] for item in attempts}, {f"run-{index}" for index in range(32)})
             self.assertTrue(all(item["usage_status"] == "authoritative" for item in attempts))
             self.assertTrue(all(item["completion_state"] == "completed" for item in attempts))
-            original_cost = totals["cost_picos"]
-            previous_rates = PROVIDER_COSTS["deepseek"]
-            try:
-                PROVIDER_COSTS["deepseek"] = (999.0, 999.0)
-                self.assertEqual(
-                    store.usage_totals(workspace_id="project", user_id="local")["cost_picos"],
-                    original_cost,
-                )
-            finally:
-                PROVIDER_COSTS["deepseek"] = previous_rates
 
     def test_reset_requires_explicit_confirmation_and_preserves_installation_ledger(self):
         with tempfile.TemporaryDirectory(prefix="openkyrozen-usage-reset-") as directory:
@@ -149,14 +144,65 @@ class UsageLedgerTests(unittest.TestCase):
             combined_mixed = store.usage_totals(
                 workspace_id="project", session_id="combined-mixed", user_id="local",
             )
-            self.assertEqual(short["cost_picos"], 110_000_000_000)
-            self.assertEqual(mixed["cost_picos"], 137_000_000_000)
+            self.assertEqual(short["cost_picos"], 132_000_000_000)
+            self.assertEqual(mixed["cost_picos"], 176_000_000_000)
             self.assertEqual(short["cost_picos"], combined_short["cost_picos"])
             self.assertEqual(mixed["cost_picos"], combined_mixed["cost_picos"])
             self.assertEqual(
                 get_cost_summary(store=store, workspace_id="project", session_id="short", scope="session"),
-                "deepseek: 0K in / 100K out ~$0.11",
+                "deepseek: 0K in / 100K out ~$0.13",
             )
+
+    def test_deepseek_v4_cache_pricing_uses_fixed_peak_and_off_peak_timestamps(self):
+        usage = {
+            "prompt_tokens": 1_000_000,
+            "prompt_cache_hit_tokens": 250_000,
+            "prompt_cache_miss_tokens": 750_000,
+            "completion_tokens": 1_000_000,
+        }
+        with tempfile.TemporaryDirectory(prefix="openkyrozen-deepseek-pricing-") as directory:
+            store = EventStore(Path(directory) / "state.sqlite3")
+            with usage_scope(store=store, workspace_id="project", session_id="peak"):
+                _track_cost("deepseek", usage, model="deepseek-v4-flash",
+                            occurred_at=datetime(2026, 9, 7, 2, tzinfo=timezone.utc))
+            with usage_scope(store=store, workspace_id="project", session_id="off-peak"):
+                _track_cost("deepseek", usage, model="deepseek-v4-flash",
+                            occurred_at=datetime(2026, 9, 7, 4, tzinfo=timezone.utc))
+
+            peak = store.usage_totals(workspace_id="project", session_id="peak", user_id="local")
+            off_peak = store.usage_totals(workspace_id="project", session_id="off-peak", user_id="local")
+            attempt = store.list_usage_attempts(workspace_id="project", session_id="peak", user_id="local")[0]
+            self.assertEqual(peak["cost_picos"], 1_653_500_000_000)
+            self.assertEqual(off_peak["cost_picos"], 826_750_000_000)
+            self.assertEqual(attempt["cache_status"], "mixed")
+            self.assertEqual(attempt["usage_status"], "authoritative")
+            self.assertEqual(attempt["pricing_snapshot"]["billing_window"], "peak")
+            self.assertEqual(attempt["pricing_snapshot"]["model"], "deepseek-v4-flash")
+
+    def test_openai_compatible_provider_preserves_deepseek_cache_usage_fields(self):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+            usage=SimpleNamespace(
+                prompt_tokens=10, completion_tokens=4,
+                prompt_cache_hit_tokens=3, prompt_cache_miss_tokens=7,
+                completion_tokens_details=SimpleNamespace(reasoning_tokens=2),
+            ),
+        )
+        provider = OpenAICompatProvider.__new__(OpenAICompatProvider)
+        provider.config = ProviderConfig(provider="deepseek")
+        provider._client = SimpleNamespace(chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **_kwargs: response),
+        ))
+        with tempfile.TemporaryDirectory(prefix="openkyrozen-deepseek-usage-") as directory:
+            store = EventStore(Path(directory) / "state.sqlite3")
+            with usage_scope(store=store, workspace_id="project"):
+                text, usage = provider.chat([], "deepseek-v4-flash")
+            attempt = store.list_usage_attempts(workspace_id="project", user_id="local")[0]
+            self.assertEqual(text, "ok")
+            self.assertEqual(usage["prompt_cache_hit_tokens"], 3)
+            self.assertEqual(attempt["cache_hit_tokens"], 3)
+            self.assertEqual(attempt["cache_miss_tokens"], 7)
+            self.assertEqual(attempt["reasoning_tokens"], 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- default DeepSeek calls to current V4 Flash/Pro models and retain compatibility aliases
- record immutable V4 peak/off-peak cache-hit/cache-miss/output pricing snapshots with official weekday UTC scheduling
- retain cache and reasoning usage fields from OpenAI-compatible responses, marking missing cache classification as estimated

## Validation
- `python -m unittest discover -s tests -p 'test_usage_ledger.py' -v`\n- `make check`\n- `make lint`\n- `make docs-check`\n- `make test` (157 passed, including browser flow)\n- `git diff --check`\n\nFixes #79