### PR TITLE
fix: persist final streamed usage

### DIFF
--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **157 unittest cases**.
+Current repository test count at this snapshot: **158 unittest cases**.
 
 ## Verified surface
 

--- a/providers.py
+++ b/providers.py
@@ -178,6 +178,19 @@ def _usage_integer(usage: dict | None, key: str) -> int | None:
         return None
 
 
+def _openai_usage_dict(usage: Any) -> dict[str, int | None] | None:
+    if usage is None:
+        return None
+    completion_details = getattr(usage, "completion_tokens_details", None)
+    return {
+        "prompt_tokens": getattr(usage, "prompt_tokens", 0) or 0,
+        "completion_tokens": getattr(usage, "completion_tokens", 0) or 0,
+        "prompt_cache_hit_tokens": getattr(usage, "prompt_cache_hit_tokens", None),
+        "prompt_cache_miss_tokens": getattr(usage, "prompt_cache_miss_tokens", None),
+        "reasoning_tokens": getattr(completion_details, "reasoning_tokens", None),
+    }
+
+
 def _track_cost(provider: str, usage: dict | None, *, model: str = "unknown",
                 latency_ms: int | None = None, completion_state: str = "completed",
                 occurred_at: datetime | None = None) -> str:
@@ -222,6 +235,7 @@ def _track_cost(provider: str, usage: dict | None, *, model: str = "unknown",
     else:
         cache_status = "miss"
     usage_status = "unknown" if usage is None else (
+        "estimated" if usage.get("_estimated") else
         "authoritative" if current_schedule and (provider != "deepseek" or cache_status != "unknown")
         else "estimated"
     )
@@ -420,14 +434,7 @@ class OpenAICompatProvider(LLMProvider):
         usage = getattr(response, "usage", None)
         usage_dict = None
         if usage is not None:
-            completion_details = getattr(usage, "completion_tokens_details", None)
-            usage_dict = {
-                "prompt_tokens": usage.prompt_tokens or 0,
-                "completion_tokens": usage.completion_tokens or 0,
-                "prompt_cache_hit_tokens": getattr(usage, "prompt_cache_hit_tokens", None),
-                "prompt_cache_miss_tokens": getattr(usage, "prompt_cache_miss_tokens", None),
-                "reasoning_tokens": getattr(completion_details, "reasoning_tokens", None),
-            }
+            usage_dict = _openai_usage_dict(usage)
         _track_cost(self.config.provider, usage_dict, model=model,
                     latency_ms=round((time.monotonic() - started) * 1000))
         return text.strip(), usage_dict
@@ -435,22 +442,39 @@ class OpenAICompatProvider(LLMProvider):
     def chat_stream(self, messages: list[dict[str, str]], model: str | None = None) -> Iterator[str]:
         model = model or self.config.model_simple
         collected: list[str] = []
+        started = time.monotonic()
+        final_usage: dict[str, int | None] | None = None
+        completed = False
 
         def _call():
             return self._client.chat.completions.create(
-                model=model, messages=messages, stream=True
+                model=model, messages=messages, stream=True,
+                stream_options={"include_usage": True},
             )
 
         stream = _retry_with_backoff(_call)
-        for chunk in stream:
-            delta = chunk.choices[0].delta if chunk.choices else None
-            if delta and delta.content:
-                collected.append(delta.content)
-                yield delta.content
-
-        # Estimate usage from collected text (rough: ~1 token per 4 chars)
-        # Real usage tracking happens in non-streaming chat() for accuracy
-        full_text = "".join(collected)
+        try:
+            for chunk in stream:
+                usage = _openai_usage_dict(getattr(chunk, "usage", None))
+                if usage is not None:
+                    final_usage = usage
+                delta = chunk.choices[0].delta if chunk.choices else None
+                if delta and delta.content:
+                    collected.append(delta.content)
+                    yield delta.content
+            completed = True
+        finally:
+            if completed:
+                if final_usage is None:
+                    final_usage = {
+                        "prompt_tokens": sum(len(str(message.get("content", ""))) for message in messages) // 4,
+                        "completion_tokens": len("".join(collected)) // 4,
+                        "_estimated": 1,
+                    }
+                _track_cost(
+                    self.config.provider, final_usage, model=model,
+                    latency_ms=round((time.monotonic() - started) * 1000),
+                )
 
 # ---------------------------------------------------------------------------
 # Anthropic (Claude)

--- a/tests/test_usage_ledger.py
+++ b/tests/test_usage_ledger.py
@@ -204,6 +204,33 @@ class UsageLedgerTests(unittest.TestCase):
             self.assertEqual(attempt["cache_miss_tokens"], 7)
             self.assertEqual(attempt["reasoning_tokens"], 2)
 
+    def test_completed_stream_records_final_usage_once(self):
+        final_usage = SimpleNamespace(
+            prompt_tokens=10, completion_tokens=4,
+            prompt_cache_hit_tokens=3, prompt_cache_miss_tokens=7,
+            completion_tokens_details=SimpleNamespace(reasoning_tokens=2),
+        )
+        chunks = [
+            SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content="STREAM"))], usage=None),
+            SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content="_OK"))], usage=None),
+            SimpleNamespace(choices=[], usage=final_usage),
+        ]
+        calls = []
+        provider = OpenAICompatProvider.__new__(OpenAICompatProvider)
+        provider.config = ProviderConfig(provider="deepseek")
+        provider._client = SimpleNamespace(chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **kwargs: calls.append(kwargs) or iter(chunks)),
+        ))
+        with tempfile.TemporaryDirectory(prefix="openkyrozen-stream-usage-") as directory:
+            store = EventStore(Path(directory) / "state.sqlite3")
+            with usage_scope(store=store, workspace_id="project"):
+                self.assertEqual(list(provider.chat_stream([], "deepseek-v4-flash")), ["STREAM", "_OK"])
+            attempts = store.list_usage_attempts(workspace_id="project", user_id="local")
+            self.assertEqual(len(attempts), 1)
+            self.assertEqual(attempts[0]["completion_tokens"], 4)
+            self.assertEqual(attempts[0]["usage_status"], "authoritative")
+            self.assertEqual(calls[0]["stream_options"], {"include_usage": True})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- request and persist the provider final stream usage frame exactly once after a completed stream
- keep interrupted streams unrecorded unless a billable frame completed, and label no-frame character estimates as estimated
- cover final usage persistence and DeepSeek stream options

## Validation
- `python -m unittest discover -s tests -p 'test_usage_ledger.py' -v`\n- `make check`\n- `make lint`\n- `make docs-check`\n- `make test` (158 passed, including browser flow)\n- `git diff --check`\n\nFixes #77