### PR TITLE
fix: persist sub-agent execution metrics

### DIFF
--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,14 +9,14 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **158 unittest cases**.
+Current repository test count at this snapshot: **160 unittest cases**.
 
 ## Verified surface
 
 | Surface | Current behavior | Verification |
 | --- | --- | --- |
 | Profile routing | `auto` routes normal requests to `coder` or `researcher`; an explicit profile wins. | `tests/test_evolution.py` |
-| Evidence ledger | Runs, tool/error receipts, acceptance evidence, latency, tokens, and artifact hashes are durable SQLite events. | `tests/test_evolution.py`, `tests/test_evolution_robustness.py` |
+| Evidence ledger | Runs, actual provider/model, ledger-backed token usage, measured latency, tool/error receipts, acceptance evidence, and artifact hashes are durable SQLite events. | `tests/test_evolution.py`, `tests/test_evolution_robustness.py`, `tests/test_subagents.py` |
 | Canary lifecycle | A learned artifact stays a canary until two distinct verified successes and a non-regressing paired replay; correction or repeated verified failures rolls it back. | `tests/test_evolution.py` |
 | Deterministic selection | Matching is profile- and trigger-scoped, with at most three artifacts and 8,000 body characters, including at most one canary. | `tests/test_causal_selection.py` |
 | Retirement | A paired omission trial can retire an artifact only when completion does not regress; restore keeps the pre-image recoverable. | `tests/test_causal_selection.py` |

--- a/event_store.py
+++ b/event_store.py
@@ -318,7 +318,7 @@ class EventStore:
 
     def list_usage_attempts(
             self, *, workspace_id: str | None = None, session_id: str | None = None,
-            user_id: str | None = None, limit: int = 1000,
+            user_id: str | None = None, run_id: str | None = None, limit: int = 1000,
     ) -> list[dict[str, Any]]:
         clauses = ["1=1"]
         params: list[Any] = []
@@ -331,6 +331,9 @@ class EventStore:
         if user_id is not None:
             clauses.append("user_id=?")
             params.append(user_id)
+        if run_id is not None:
+            clauses.append("run_id=?")
+            params.append(run_id)
         params.append(max(1, min(limit, 10000)))
         with self.connection() as db:
             rows = db.execute(
@@ -341,13 +344,13 @@ class EventStore:
 
     def usage_totals(
             self, *, workspace_id: str | None = None, session_id: str | None = None,
-            user_id: str | None = None, since: str | None = None,
+            user_id: str | None = None, run_id: str | None = None, since: str | None = None,
     ) -> dict[str, Any]:
         """Aggregate immutable usage records for one explicit durable scope."""
         clauses = ["1=1"]
         params: list[Any] = []
         for field, value in (("workspace_id", workspace_id), ("session_id", session_id),
-                             ("user_id", user_id)):
+                             ("user_id", user_id), ("run_id", run_id)):
             if value is not None:
                 clauses.append(f"{field}=?")
                 params.append(value)

--- a/learning_engine.py
+++ b/learning_engine.py
@@ -150,7 +150,7 @@ class LearningEngine:
         return "\n".join(lines), receipts
 
     def complete_run(self, run: dict[str, str], *, result: str, receipts: list[dict[str, Any]],
-                     tools: list[dict[str, Any]], tokens: int, latency: float,
+                     tools: list[dict[str, Any]], tokens: int | None, latency: float | None,
                      acceptance: list[dict[str, Any]] | None = None,
                      provider_error: bool = False) -> None:
         errors = sum(1 for item in tools if not item.get("success"))
@@ -158,8 +158,10 @@ class LearningEngine:
             {"task": run.get("task"), "result": result, "tools": tools}, ensure_ascii=False,
         )))
         payload = {**run, "result": str(result)[:4000], "receipts": receipts, "tools": tools[:50],
-                   "tool_calls": len(tools), "errors": errors, "tokens": max(0, int(tokens)),
-                   "latency": max(0.0, float(latency)), "provider_error": bool(provider_error),
+                   "tool_calls": len(tools), "errors": errors,
+                   "tokens": None if tokens is None else max(0, int(tokens)),
+                   "latency": None if latency is None else max(0.0, float(latency)),
+                   "provider_error": bool(provider_error),
                    "acceptance_evidence": (acceptance or [])[:20],
                    "contains_secret": contains_secret,
                    "eligible": not provider_error and not contains_secret and len(tools) >= 2}
@@ -652,7 +654,7 @@ class LearningEngine:
             recurrence = sum(item["payload"].get("task_signature") == payload.get("task_signature")
                              for item in completed)
             score = recurrence * 2 + int(payload["run_id"] in requested) * 5 + int(payload.get("errors", 0)) * 2
-            score += min(5, int(payload.get("tokens", 0)) // 1000)
+            score += min(5, int(payload.get("tokens") or 0) // 1000)
             candidates.append((score, event["created_at"], payload))
         candidates.sort(key=lambda item: (-item[0], item[1]))
         return [payload for _, _, payload in candidates[:limit]]
@@ -803,8 +805,8 @@ class LearningEngine:
             "correction_rate": (sum(bool(item.get("correction")) for item in verified) / len(verified)) if verified else None,
             "repeated_error_rate": (sum(item.get("errors", 0) > 1 for item in completed) / len(completed)) if completed else None,
             "tool_calls": sum(int(item.get("tool_calls", 0)) for item in completed),
-            "tokens": sum(int(item.get("tokens", 0)) for item in completed),
-            "latency": sum(float(item.get("latency", 0.0)) for item in completed),
+            "tokens": sum(int(item.get("tokens") or 0) for item in completed),
+            "latency": sum(float(item.get("latency") or 0.0) for item in completed),
             "task_families": families,
             "context_chars": sum(sum(int(receipt.get("chars", 0)) for receipt in item.get("receipts", []))
                                  for item in outcomes),

--- a/main.py
+++ b/main.py
@@ -2348,7 +2348,7 @@ def _run_subagent_tool(profile: AgentProfile, action: str, args: Any, tools: set
     }
 
 
-def _run_subagent_llm(profile: AgentProfile, task: str, context: list[dict[str, Any]], tools: set[str]) -> dict[str, Any]:
+def _run_subagent_llm_result(profile: AgentProfile, task: str, context: list[dict[str, Any]], tools: set[str]) -> dict[str, Any]:
     memory_lines = "\n".join(
         f"- kind={item.get('kind')} confidence={item.get('confidence', 0):.2f}: {str(item.get('content', ''))[:500]}"
         for item in context
@@ -2421,7 +2421,66 @@ def _run_subagent_llm(profile: AgentProfile, task: str, context: list[dict[str, 
     return {"result": response, "tool_records": tool_records, "evidence": evidence}
 
 
-subagent_manager = SubAgentManager(memory_bank, runner=_run_subagent_llm, learning_engine=learning_engine)
+def _subagent_usage_metrics(run_id: str, started: float) -> dict[str, Any]:
+    """Read one sub-agent's actual provider usage from the durable ledger."""
+    attempts = memory_bank.store.list_usage_attempts(
+        user_id=memory_bank.user_id, workspace_id=memory_bank.workspace_id, run_id=run_id,
+    )
+    totals = memory_bank.store.usage_totals(
+        user_id=memory_bank.user_id, workspace_id=memory_bank.workspace_id, run_id=run_id,
+    )
+
+    def known_total(field: str) -> int | None:
+        if not attempts or any(item.get(field) is None for item in attempts):
+            return None
+        return int(totals[field])
+
+    provider_models = sorted({f"{item['provider']}:{item['model']}" for item in attempts})
+    statuses = {str(item.get("usage_status") or "unknown") for item in attempts}
+    return {
+        "provider_model": provider_models[0] if len(provider_models) == 1 else (
+            "mixed" if provider_models else "unknown"
+        ),
+        "provider_models": provider_models,
+        "attempts": int(totals["attempts"]),
+        "prompt_tokens": known_total("prompt_tokens"),
+        "completion_tokens": known_total("completion_tokens"),
+        "reasoning_tokens": known_total("reasoning_tokens"),
+        "tokens": (
+            int(totals["prompt_tokens"]) + int(totals["completion_tokens"])
+            if known_total("prompt_tokens") is not None and known_total("completion_tokens") is not None else None
+        ),
+        "latency_ms": round((time.monotonic() - started) * 1000, 3),
+        "usage_status": (
+            next(iter(statuses)) if len(statuses) == 1 else "mixed" if statuses else "unknown"
+        ),
+    }
+
+
+def _run_subagent_llm(profile: AgentProfile, task: str, context: list[dict[str, Any]], tools: set[str], *,
+                      run_id: str | None = None) -> dict[str, Any]:
+    started = time.monotonic()
+    token = _active_usage_run_id.set(run_id) if run_id else None
+    try:
+        result = _run_subagent_llm_result(profile, task, context, tools)
+        if run_id:
+            result["metrics"] = _subagent_usage_metrics(run_id, started)
+        return result
+    finally:
+        if token is not None:
+            _active_usage_run_id.reset(token)
+
+
+def _subagent_provider_model() -> str:
+    if _provider_config and DEEPSEEK_MODEL:
+        return f"{_provider_config.provider}:{DEEPSEEK_MODEL}"
+    return "unknown"
+
+
+subagent_manager = SubAgentManager(
+    memory_bank, runner=_run_subagent_llm, learning_engine=learning_engine,
+    provider_model=_subagent_provider_model,
+)
 
 # ---- Tool to let agent examine its own memory ----
 def _check_stored_data(args: str) -> str:

--- a/subagents.py
+++ b/subagents.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import time
 import uuid
 from dataclasses import dataclass, field
 from typing import Any, Callable, TYPE_CHECKING
@@ -27,11 +28,13 @@ class AgentProfile:
 
 
 class SubAgentManager:
-    def __init__(self, memory: MemoryBank, *, runner: Callable[[AgentProfile, str, list[dict[str, Any]], set[str]], str | dict[str, Any]] | None = None,
-                 learning_engine: "LearningEngine | None" = None):
+    def __init__(self, memory: MemoryBank, *, runner: Callable[..., str | dict[str, Any]] | None = None,
+                 learning_engine: "LearningEngine | None" = None,
+                 provider_model: Callable[[], str] | None = None):
         self.memory = memory
         self.runner = runner
         self.learning_engine = learning_engine
+        self.provider_model = provider_model
         self.profiles: dict[str, AgentProfile] = {}
         self.register(AgentProfile("researcher", "Research the task, cite evidence, and separate facts from assumptions.", "readonly"))
         self.register(AgentProfile("coder", "Inspect and modify code only when requested; verify every change.", "workspace"))
@@ -71,10 +74,11 @@ class SubAgentManager:
             task, n_results=5, profile=profile.name,
             task_signature=self.learning_engine.task_signature(profile.name, task) if self.learning_engine else None,
         ) if profile.memory_scope != "none" else [])
+        expected_provider_model = self.provider_model() if self.provider_model else "unknown"
         learning_run = None
         receipts: list[dict[str, Any]] = []
         if self.learning_engine and profile.evolution_enabled and profile.name in {"coder", "researcher"}:
-            learning_run = self.learning_engine.begin_run(profile.name, task)
+            learning_run = self.learning_engine.begin_run(profile.name, task, provider_model=expected_provider_model)
             guidance, receipts = self.learning_engine.artifact_context(learning_run)
             if guidance:
                 context.append({"kind": "learned_guidance", "confidence": 1.0, "content": guidance})
@@ -83,21 +87,51 @@ class SubAgentManager:
                                        user_id=self.memory.user_id, workspace_id=workspace_id, session_id=run_id)
         tool_records: list[dict[str, Any]] = []
         evidence: list[dict[str, Any]] = []
+        metrics: dict[str, Any] = {
+            "provider_model": expected_provider_model or "unknown", "provider_models": [], "attempts": None,
+            "prompt_tokens": None, "completion_tokens": None, "reasoning_tokens": None, "tokens": None,
+            "latency_ms": None, "usage_status": "unknown",
+        }
         provider_error = False
+        started = time.monotonic()
         if self.runner is None:
             result = "Sub-agent runner is not configured."
         else:
             try:
-                raw_result = self.runner(profile, task, context, tools)
+                raw_result = self.runner(profile, task, context, tools, run_id=run_id)
                 if isinstance(raw_result, dict):
                     result = str(raw_result.get("result", ""))
                     tool_records = [item for item in raw_result.get("tool_records", []) if isinstance(item, dict)]
                     evidence = [item for item in raw_result.get("evidence", []) if isinstance(item, dict)]
+                    if isinstance(raw_result.get("metrics"), dict):
+                        metrics.update({key: raw_result["metrics"][key] for key in metrics
+                                        if key in raw_result["metrics"]})
                 else:
                     result = str(raw_result)
             except Exception as exc:
                 provider_error = True
                 result = f"Sub-agent failed: {type(exc).__name__}: {exc}"
+        if not isinstance(metrics.get("provider_model"), str) or not metrics["provider_model"].strip():
+            metrics["provider_model"] = expected_provider_model or "unknown"
+        metrics["provider_model"] = str(metrics["provider_model"]).strip()[:192]
+        metrics["provider_models"] = [str(item)[:192] for item in metrics["provider_models"]] if isinstance(
+            metrics["provider_models"], (list, tuple, set)
+        ) else []
+        if metrics["usage_status"] not in {"authoritative", "estimated", "mixed", "unknown"}:
+            metrics["usage_status"] = "unknown"
+        for field in ("attempts", "prompt_tokens", "completion_tokens", "reasoning_tokens", "tokens"):
+            try:
+                metrics[field] = None if metrics[field] is None else max(0, int(metrics[field]))
+            except (TypeError, ValueError):
+                metrics[field] = None
+        try:
+            metrics["latency_ms"] = None if metrics["latency_ms"] is None else max(0.0, float(metrics["latency_ms"]))
+        except (TypeError, ValueError):
+            metrics["latency_ms"] = None
+        if metrics.get("latency_ms") is None:
+            metrics["latency_ms"] = (time.monotonic() - started) * 1000
+        if learning_run:
+            learning_run["provider_model"] = metrics["provider_model"]
 
         for record in tool_records:
             payload = {"run_id": run_id, **record}
@@ -119,13 +153,16 @@ class SubAgentManager:
                                                                "result": str(result)[:4000],
                                                                "tool_receipts": tool_records[:50],
                                                                "acceptance_evidence": evidence[:20],
+                                                               "metrics": metrics,
                                                                "provider_error": provider_error},
                                        user_id=self.memory.user_id, workspace_id=workspace_id, session_id=run_id)
         scoped_memory.add_log(str(result), kind="episodic", status="active",
                               metadata={"subagent_run_id": run_id, "profile": profile.name})
         if learning_run:
             self.learning_engine.complete_run(learning_run, result=str(result), receipts=receipts,
-                                              tools=tool_records, tokens=0, latency=0.0,
+                                              tools=tool_records, tokens=metrics.get("tokens"),
+                                              latency=(float(metrics["latency_ms"]) / 1000
+                                                       if metrics.get("latency_ms") is not None else None),
                                               acceptance=evidence, provider_error=provider_error)
             if evidence:
                 self.learning_engine.record_outcome(
@@ -135,4 +172,4 @@ class SubAgentManager:
                 )
         return {"run_id": run_id, "profile": profile.name, "result": str(result),
                 "tools": sorted(tools), "memory_scope": profile.memory_scope,
-                "tool_receipts": tool_records, "evidence": evidence}
+                "tool_receipts": tool_records, "evidence": evidence, "metrics": metrics}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -55,6 +55,11 @@ class ServerBoundaryTests(unittest.TestCase):
             self.assertFalse((root / "denied.txt").exists())
             self.assertFalse(denied.json()["tool_receipts"][0]["success"])
             self.assertFalse(denied.json()["tool_receipts"][0]["authorized"])
+            completed = next(event for event in manager.memory.store.list_events(
+                "subagent.completed", workspace_id=server._agent.memory_bank.workspace_id,
+                session_id=allowed.json()["run_id"], limit=10,
+            ))
+            self.assertEqual(completed["payload"]["metrics"], allowed.json()["metrics"])
             events = manager.memory.store.list_events(
                 workspace_id=server._agent.memory_bank.workspace_id,
                 session_id=denied.json()["run_id"], limit=20,

--- a/tests/test_subagents.py
+++ b/tests/test_subagents.py
@@ -132,7 +132,9 @@ class SubAgentTests(unittest.TestCase):
                 memory, runner=main._run_subagent_llm, learning_engine=LearningEngine(memory),
                 provider_model=lambda: "deepseek:deepseek-v4-flash",
             )
-            with patch.object(main, "memory_bank", memory), patch.object(main, "llm_provider", provider):
+            with (patch.object(main, "memory_bank", memory),
+                  patch.object(main, "llm_provider", provider),
+                  patch.object(main, "DEEPSEEK_MODEL", "deepseek-v4-flash")):
                 result = manager.run("researcher", "report the result")
             ledger = memory.store.usage_totals(workspace_id="project", run_id=result["run_id"])
             completed = memory.store.list_events(

--- a/tests/test_subagents.py
+++ b/tests/test_subagents.py
@@ -2,10 +2,13 @@ import tempfile
 import unittest
 from unittest.mock import patch
 from pathlib import Path
+from types import SimpleNamespace
 
 from event_store import EventStore
+from learning_engine import LearningEngine
 from memory import MemoryBank
 import main
+from providers import OpenAICompatProvider, ProviderConfig
 from subagents import AgentProfile, SubAgentManager
 
 
@@ -13,7 +16,9 @@ class SubAgentTests(unittest.TestCase):
     def test_profile_has_independent_session_memory_and_capabilities(self):
         with tempfile.TemporaryDirectory() as directory:
             memory = MemoryBank(Path(directory) / "state.sqlite3", workspace_id="project")
-            manager = SubAgentManager(memory, runner=lambda profile, task, context, tools: f"done:{profile.name}")
+            manager = SubAgentManager(
+                memory, runner=lambda profile, task, context, tools, *, run_id: f"done:{profile.name}",
+            )
             manager.register(AgentProfile("tester", "Return a test result", "readonly"))
             result = manager.run("tester", "check the repository")
             self.assertTrue(result["run_id"].startswith("subagent_"))
@@ -66,7 +71,7 @@ class SubAgentTests(unittest.TestCase):
     def test_manager_persists_tool_receipts_failures_and_evidence(self):
         with tempfile.TemporaryDirectory() as directory:
             memory = MemoryBank(Path(directory) / "state.sqlite3", workspace_id="project")
-            manager = SubAgentManager(memory, runner=lambda profile, task, context, tools: {
+            manager = SubAgentManager(memory, runner=lambda profile, task, context, tools, *, run_id: {
                 "result": "completed",
                 "tool_records": [{"receipt_id": "receipt-1", "action": "write_file",
                                   "args": "marker.txt|ok", "result": "wrote", "success": True,
@@ -85,6 +90,59 @@ class SubAgentTests(unittest.TestCase):
             self.assertIn("subagent.evidence", event_types)
             completed = next(event for event in events if event["event_type"] == "subagent.completed")
             self.assertEqual(len(completed["payload"]["tool_receipts"]), 2)
+
+    def test_manager_persists_nonzero_runner_metrics_without_zero_fallback(self):
+        with tempfile.TemporaryDirectory() as directory:
+            memory = MemoryBank(Path(directory) / "state.sqlite3", workspace_id="project")
+            manager = SubAgentManager(
+                memory, learning_engine=LearningEngine(memory),
+                provider_model=lambda: "deepseek:deepseek-v4-flash",
+                runner=lambda profile, task, context, tools, *, run_id: {
+                    "result": "completed",
+                    "metrics": {"provider_model": "deepseek:deepseek-v4-flash", "tokens": 37,
+                                "latency_ms": 250, "usage_status": "authoritative"},
+                },
+            )
+            result = manager.run("researcher", "report the result")
+            completed = memory.store.list_events(
+                "learning.run_completed", workspace_id="project", limit=10,
+            )[0]["payload"]
+            self.assertEqual(result["metrics"]["tokens"], 37)
+            self.assertEqual(completed["provider_model"], "deepseek:deepseek-v4-flash")
+            self.assertEqual(completed["tokens"], 37)
+            self.assertEqual(completed["latency"], 0.25)
+
+    def test_main_subagent_runner_uses_its_usage_ledger_rows(self):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="sub-agent complete"))],
+            usage=SimpleNamespace(
+                prompt_tokens=10, completion_tokens=4,
+                prompt_cache_hit_tokens=3, prompt_cache_miss_tokens=7,
+                completion_tokens_details=SimpleNamespace(reasoning_tokens=2),
+            ),
+        )
+        provider = OpenAICompatProvider.__new__(OpenAICompatProvider)
+        provider.config = ProviderConfig(provider="deepseek")
+        provider._client = SimpleNamespace(chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **_kwargs: response),
+        ))
+        with tempfile.TemporaryDirectory() as directory:
+            memory = MemoryBank(Path(directory) / "state.sqlite3", workspace_id="project")
+            manager = SubAgentManager(
+                memory, runner=main._run_subagent_llm, learning_engine=LearningEngine(memory),
+                provider_model=lambda: "deepseek:deepseek-v4-flash",
+            )
+            with patch.object(main, "memory_bank", memory), patch.object(main, "llm_provider", provider):
+                result = manager.run("researcher", "report the result")
+            ledger = memory.store.usage_totals(workspace_id="project", run_id=result["run_id"])
+            completed = memory.store.list_events(
+                "learning.run_completed", workspace_id="project", limit=10,
+            )[0]["payload"]
+            self.assertEqual(result["metrics"]["provider_model"], "deepseek:deepseek-v4-flash")
+            self.assertEqual(result["metrics"]["tokens"], 14)
+            self.assertEqual(ledger["prompt_tokens"], 10)
+            self.assertEqual(ledger["completion_tokens"], 4)
+            self.assertEqual(completed["tokens"], 14)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- attribute every production sub-agent provider call to its durable run ID
- return and persist provider/model, ledger-backed usage, receipts, evidence, and measured latency
- preserve unknown measurements as `null`, never fabricated zeroes

## Validation
- `./venv/bin/python -m unittest tests.test_subagents tests.test_server tests.test_usage_ledger -v`
- `make check`
- `make lint`
- live DeepSeek attempt reached the provider but the locally configured credential was rejected; the isolated regression covers the same production ledger path

Fixes #84