### PR TITLE
fix: classify git_branch as a git capability

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -280,6 +280,8 @@ kyrozen
 
 31 個すべてのランタイムツールは、JSON アクションブロック内でプレーン文字列の `args` フィールドを受け付けます。ツール名、能力ラベル、MCP 入力 schema、実際の HTTP ルートは[生成されたランタイムインベントリ](docs/tool-inventory.md)を正とします：
 
+`git_branch` を含む組み込み Git ツールには `git` 能力が必要で、`dynamic` はユーザー定義ツール専用です。
+
 ```json
 {"action": "read_file", "args": "README.md"}
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -280,6 +280,8 @@ kyrozen
 
 모든 31개 런타임 도구는 JSON 액션 블록에서 일반 문자열 `args` 필드를 허용합니다. 도구 이름, capability 라벨, MCP 입력 schema 및 실제 HTTP 경로는[생성된 런타임 인벤토리](docs/tool-inventory.md)를 기준으로 합니다:
 
+`git_branch`를 포함한 기본 Git 도구에는 `git` capability가 필요하며, `dynamic`은 사용자 정의 도구 전용입니다.
+
 ```json
 {"action": "read_file", "args": "README.md"}
 ```

--- a/README.md
+++ b/README.md
@@ -367,6 +367,9 @@ The [generated runtime inventory](docs/tool-inventory.md) is authoritative for
 tool names, capability labels, MCP input schemas, and the live HTTP endpoint
 list:
 
+Built-in Git tools, including `git_branch`, require the `git` capability;
+`dynamic` is reserved for user-defined tools.
+
 ```json
 {"action": "read_file", "args": "README.md"}
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -277,6 +277,8 @@ kyrozen
 所有 31 项运行时工具在 JSON 动作块中接受纯字符串 `args` 字段。完整的
 工具名称、能力标签、MCP 输入 schema 和实时 HTTP 路由以[生成的运行时清单](docs/tool-inventory.md)为准：
 
+包括 `git_branch` 在内的内置 Git 工具需要 `git` 能力；`dynamic` 仅用于用户定义的工具。
+
 ```json
 {"action": "read_file", "args": "README.md"}
 ```

--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **161 unittest cases**.
+Current repository test count at this snapshot: **162 unittest cases**.
 
 ## Verified surface
 

--- a/docs/tool-inventory.md
+++ b/docs/tool-inventory.md
@@ -24,7 +24,7 @@ Run `make docs-check` after changing a tool, endpoint, or MCP contract.
 | `execute_terminal_command` | `shell` | Execute a terminal command. This is an alias for run_cmd. | `command`: string; required: `command` |
 | `find_files` | `read` | Find files matching a pattern. Args format: "pattern" or "pattern\|directory". | `pattern`: string, `directory`: string; required: `pattern` |
 | `git_add` | `git` | Stage files for commit. Args format: "file1 file2" or "." (stage all). | `args`: string |
-| `git_branch` | `dynamic` | List or manage git branches. Args format: "" (list all), "branch_name" (create), | `args`: string |
+| `git_branch` | `git` | List or manage git branches. Args format: "" (list all), "branch_name" (create), | `args`: string |
 | `git_checkout` | `git` | Switch branches or restore files. Args format: "branch_name" (switch), | `args`: string |
 | `git_clone` | `git` | Clone a git repository. Args format: "url" or "url\|destination". | `url`: string, `destination`: string; required: `url` |
 | `git_commit` | `git` | Commit staged changes. Args format: '"commit message"' (quotes recommended). | `args`: string |

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -258,6 +258,48 @@ class ServerBoundaryTests(unittest.TestCase):
         with patch.dict(os.environ, {"KYROZEN_MCP_CAPABILITIES": "full"}):
             self.assertIn("git_reset", server._allowed_server_tools("mcp"))
 
+    def test_git_branch_uses_git_capability_across_surfaces(self):
+        from tools import tool_capability
+
+        self.assertEqual(tool_capability("git_branch"), "git")
+        with patch.dict(os.environ, {
+            "KYROZEN_MCP_CAPABILITIES": "workspace",
+            "KYROZEN_WEB_CAPABILITIES": "workspace",
+        }):
+            self.assertIn("git_branch", server._allowed_server_tools("mcp"))
+            self.assertIn("git_branch", server._allowed_server_tools("web"))
+            listing = TestClient(server.app).post("/mcp", json={
+                "jsonrpc": "2.0", "id": 76, "method": "tools/list", "params": {},
+            }).json()
+        self.assertIn("git_branch", {item["name"] for item in listing["result"]["tools"]})
+
+        with patch.dict(os.environ, {
+            "KYROZEN_MCP_CAPABILITIES": "readonly",
+            "KYROZEN_WEB_CAPABILITIES": "readonly",
+        }):
+            self.assertNotIn("git_branch", server._allowed_server_tools("mcp"))
+            self.assertNotIn("git_branch", server._allowed_server_tools("web"))
+            denied = TestClient(server.app).post("/mcp", json={
+                "jsonrpc": "2.0", "id": 77, "method": "tools/call",
+                "params": {"name": "git_branch", "arguments": {"args": ""}},
+            }).json()
+        self.assertEqual(denied["error"]["code"], -32001)
+
+        with tempfile.TemporaryDirectory(prefix="openkyrozen-git-branch-") as directory:
+            root = Path(directory).resolve()
+            subprocess.run(["git", "init", "--quiet", str(root)], check=True)
+            previous_root = server._agent._get_workspace_root()
+            server._agent._set_workspace_root(root)
+            try:
+                with patch.dict(os.environ, {"KYROZEN_MCP_CAPABILITIES": "workspace"}):
+                    allowed = TestClient(server.app).post("/mcp", json={
+                        "jsonrpc": "2.0", "id": 78, "method": "tools/call",
+                        "params": {"name": "git_branch", "arguments": {"args": ""}},
+                    }).json()
+            finally:
+                server._agent._set_workspace_root(previous_root)
+        self.assertFalse(allowed["result"]["isError"])
+
     def test_cli_approval_denies_noninteractive_high_impact_action(self):
         with patch.object(server._agent, "_EXECUTION_SURFACE", "cli"):
             with patch.dict(os.environ, {"KYROZEN_APPROVAL_MODE": "dangerous"}):

--- a/tools.py
+++ b/tools.py
@@ -1048,6 +1048,7 @@ _TOOL_CAPABILITIES: dict[str, str] = {
     "search_web": "network",
     "read_webpage": "network",
     "git_clone": "git",
+    "git_branch": "git",
     "analyze_remote_repo": "network",
     "browser_open": "browser",
     "browser_snapshot": "browser",


### PR DESCRIPTION
## Summary
- classify the built-in `git_branch` action as `git` at the shared capability registry
- expose and authorize it consistently for CLI, Web, and MCP workspace profiles while retaining readonly denial
- regenerate `docs/tool-inventory.md` and document the capability contract in all four README languages
- add a regression covering discovery, allow/deny behavior, and a real temporary Git repository call

## Validation
- `./venv/bin/python -m unittest tests.test_server.ServerBoundaryTests.test_git_branch_uses_git_capability_across_surfaces -v`
- `make check`
- `make lint`
- `make docs-check`
- `git diff --check`
- `make test` (162 tests)

Fixes #76
