### PR TITLE
fix: defer startup endpoint reporting to uvicorn

### DIFF
--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **162 unittest cases**.
+Current repository test count at this snapshot: **163 unittest cases**.
 
 ## Verified surface
 

--- a/server.py
+++ b/server.py
@@ -1773,7 +1773,7 @@ async def startup():
                                   job_id="job_learning_cycle", delay_seconds=0)
     _scheduler.start()
     _audit("STARTUP", "server started")
-    print("[Server] Ready — http://127.0.0.1:8000 (set KYROZEN_SERVER_TOKEN for remote access)")
+    print("[Server] Ready — Uvicorn will report the effective bind address (set KYROZEN_SERVER_TOKEN for remote access)")
 
 
 @app.on_event("shutdown")

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -1,4 +1,5 @@
 import os
+import inspect
 import shutil
 import subprocess
 import sys
@@ -6,6 +7,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
+from types import SimpleNamespace
 
 import tomllib
 
@@ -105,6 +107,16 @@ class DistributionTests(unittest.TestCase):
         self.assertEqual(args.host, "0.0.0.0")
         self.assertEqual(args.port, 8123)
         self.assertTrue(args.reload)
+
+    def test_custom_web_launch_does_not_claim_a_fixed_endpoint(self):
+        import server
+
+        self.assertNotIn("http://127.0.0.1:8000", inspect.getsource(server.startup))
+        with patch.object(server, "_parse_server_args", return_value=(
+                SimpleNamespace(host="127.0.0.1", port=8876, reload=False), None)), \
+             patch.object(server.uvicorn, "run") as run:
+            server.main_entry()
+        run.assert_called_once_with(server.app, host="127.0.0.1", port=8876, reload=False)
 
     def test_update_uses_the_package_manager_instead_of_git_pull(self):
         import main


### PR DESCRIPTION
## Summary
- remove OpenKyrozen's hard-coded `127.0.0.1:8000` ready URL
- leave effective host/port reporting to Uvicorn, with only a generic readiness note
- add a non-default-port launch regression that verifies the actual bind arguments

## Validation
- `./venv/bin/python -m unittest tests.test_distribution.DistributionTests.test_custom_web_launch_does_not_claim_a_fixed_endpoint -v`
- `make check`
- `make lint`
- `make docs-check`
- `git diff --check`
- `make test` (163 tests)

Fixes #82
