### PR TITLE
fix: publish reproducible v2.0.1 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,22 +1,16 @@
-name: Publish OpenKyrozen
+name: Release OpenKyrozen
 
 on:
   push:
     tags:
-      - "v*"
+      - "v2.0.1"
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
-  build-test-publish:
+  build-release:
     runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/openkyrozen
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -25,17 +19,39 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Build and validate distributions
+      - name: Build and validate release artifacts
         run: |
           python -m pip install --upgrade pip build twine
-          python -m build
+          test "${GITHUB_REF_NAME#v}" = "$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          python -m build --sdist --wheel --outdir dist
           python -m twine check dist/*
 
       - name: Clean wheel installation smoke test
         run: |
           python scripts/wheel_smoke.py
 
-      - name: Publish to PyPI with Trusted Publishing
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist/
+      - name: Create immutable GitHub release and upload artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/* --verify-tag \
+            --title "OpenKyrozen $GITHUB_REF_NAME" --generate-notes
+
+  windows-installer:
+    needs: build-release
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install the pinned release with PowerShell installer
+        shell: pwsh
+        run: |
+          $auditHome = Join-Path $env:RUNNER_TEMP "openkyrozen-release-home"
+          New-Item -ItemType Directory -Force -Path $auditHome | Out-Null
+          $env:HOME = $auditHome
+          $env:USERPROFILE = $auditHome
+          & "$PWD/install.ps1"
+          $bin = Join-Path $auditHome ".local\bin"
+          & (Join-Path $bin "kyrozen.exe") --version
+          & (Join-Path $bin "kyrozen.exe") --help *> $null
+          & (Join-Path $bin "kyrozen-web.exe") --help *> $null

--- a/README.ja.md
+++ b/README.ja.md
@@ -90,16 +90,16 @@ OpenKyrozen はターミナルで動作する**自己学習型 AI エージェ�
 macOS または Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/install.sh | sh
 ```
 
 Windows PowerShell：
 
 ```powershell
-irm https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/install.ps1 | iex
 ```
 
-インストーラーは OS、アーキテクチャ、Python、ネットワーク、ユーザーパスの書き込み可否を確認し、必要なら `uv` を導入します。その後、分離された `uv` ツール環境に `openkyrozen[web]` をインストールし、プライベートな `~/.kyrozen` 状態ディレクトリを作成して `kyrozen --version` と `kyrozen --help` を検証します。API キーを読み取り、表示、アップロードすることはありません。初回の `kyrozen` 起動でプロバイダー設定を案内します。
+インストーラーは不変の GitHub `v2.0.1` リリース wheel を取得し、OS、アーキテクチャ、Python、ネットワーク、ユーザーパスの書き込み可否を確認します。必要なら `uv` を導入し、分離された `uv` ツール環境に Web 依存関係を用意して、プライベートな `~/.kyrozen` 状態ディレクトリを作成し、`kyrozen --version` と `kyrozen --help` を検証します。API キーを読み取り、表示、アップロードすることはありません。初回の `kyrozen` 起動でプロバイダー設定を案内します。
 
 ### 開発専用のソースチェックアウト
 
@@ -120,16 +120,17 @@ run.bat
 これらのコマンドは明示的にプロジェクトモード（`--project .`）で動作し、リポジトリ開発専用です。
 `make install` は完全な `.[all]` 開発依存関係と Chromium を導入するため、`make test` でブラウザー統合フローも実行します。軽量な非ブラウザーパスには `make install-core` と `make test-core` を使用してください。
 
-### PyPI からのパッケージインストール
+### 固定 GitHub リリースからのインストール
 
 ```bash
-uv tool install 'openkyrozen[web]'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+uv tool install --python 3.12 --force --with fastapi --with uvicorn "$release_url"
 
 # 対応済みの Python 環境ではこちらも使用できます：
-pip install 'openkyrozen[web]'
+pip install fastapi uvicorn "$release_url"
 ```
 
-インストール後は任意の呼び出し元ディレクトリから `kyrozen` と `kyrozen-web` を実行できます。暗号化されたプロバイダー設定は `~/.kyrozen_config.json` に保存されます。
+GitHub Actions がリリース wheel をビルド・検証します。詳しくは [v2.0.1 リリース](https://github.com/EvanProgramming/OpenKyrozen/releases/tag/v2.0.1) を参照してください。インストール後は任意の呼び出し元ディレクトリから `kyrozen` と `kyrozen-web` を実行できます。暗号化されたプロバイダー設定は `~/.kyrozen_config.json` に保存されます。
 
 ---
 
@@ -170,7 +171,7 @@ Kyrozen は：
 | `/api_key` | API キーを変更 |
 | `/learn` | プロジェクトファイルを即座にメモリにスキャン |
 | `/forget` | 最近の学習を表示；`/forget キーワード` で誤った学習を削除 |
-| `/update` | `uv tool upgrade openkyrozen` でインストール済みパッケージを更新（プロジェクトへ git pull しない） |
+| `/update` | 固定された GitHub `v2.0.1` リリース wheel を再インストール（プロジェクトへ git pull しない） |
 | `/self-learning` | 個別の自己学習機能をオン/オフ |
 
 ### Web UI モード
@@ -443,7 +444,8 @@ curl -sS -X DELETE http://127.0.0.1:8000/api/v2/memory/claims/<claim_id>
 ## 🌐 Web UI と REST API
 
 ```bash
-pip install 'openkyrozen[web]'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+pip install fastapi uvicorn "$release_url"
 kyrozen-web --port 8000
 # http://localhost:8000 を開く
 
@@ -658,15 +660,18 @@ GitHub Actions がプッシュと PR ごとに自動実行：
 - Windows PowerShell インストーラーの構文とヘルプ経路のチェック
 - Docker ビルドとコンテナ置換後の復元スモークテスト
 
-`v*` タグをプッシュすると、sdist/wheel をビルドして検証し、設定済みの
-`pypi` 環境ゲート後に GitHub Trusted Publishing で PyPI へ公開します。
+`v2.0.1` タグをプッシュすると、sdist/wheel をビルドして検証し、成果物を
+含む GitHub Release を作成して、Windows で PowerShell インストーラーを検証します。
+公開インストーラーと `/update` は、将来のバージョンを意図的に公開するまで
+このリリースに固定されます。
 
-### pip パッケージ
+### リリース wheel
 
 ```bash
-# 公開パッケージ（インストーラーが uv と Python の設定も行います）
-uv tool install 'openkyrozen[web]'
-pip install 'openkyrozen[web]'
+# 不変の GitHub リリース（インストーラーが uv と Python の設定も行います）
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+uv tool install --python 3.12 --force --with fastapi --with uvicorn "$release_url"
+pip install fastapi uvicorn "$release_url"
 
 # ローカルチェックアウトのみ（開発）
 pip install .                   # コア + CLI
@@ -695,7 +700,7 @@ OpenKyrozen/
 ├── prompts/             # プロンプトテンプレート（役割、指示、例）
 ├── docs/tool-inventory.md # 生成されたランタイムツール/ルート一覧
 ├── scripts/              # 再現可能なドキュメント/スモークチェック
-└── .github/workflows/   # CI、リリース、PyPI 公開パイプライン
+└── .github/workflows/   # CI とタグ付き GitHub リリースパイプライン
 ```
 
 ---

--- a/README.ko.md
+++ b/README.ko.md
@@ -90,16 +90,16 @@ OpenKyrozen은 터미널에서 실행되는 **자기 학습형 AI 에이전트**
 macOS 또는 Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/install.sh | sh
 ```
 
 Windows PowerShell:
 
 ```powershell
-irm https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/install.ps1 | iex
 ```
 
-설치 프로그램은 OS, 아키텍처, Python, 네트워크와 사용자 경로 쓰기 권한을 확인하고, 필요하면 `uv`를 설치합니다. 격리된 `uv` 도구 환경에 `openkyrozen[web]`을 설치하고, 비공개 `~/.kyrozen` 상태 디렉터리를 만든 뒤 `kyrozen --version`과 `kyrozen --help`를 검증합니다. API 키를 읽거나 출력하거나 업로드하지 않으며, 첫 `kyrozen` 실행에서 제공자 설정을 안내합니다.
+설치 프로그램은 변경할 수 없는 GitHub `v2.0.1` 릴리스 wheel을 가져와 OS, 아키텍처, Python, 네트워크와 사용자 경로 쓰기 권한을 확인합니다. 필요하면 `uv`를 설치하고, 격리된 `uv` 도구 환경에 Web 의존성을 준비하며, 비공개 `~/.kyrozen` 상태 디렉터리를 만든 뒤 `kyrozen --version`과 `kyrozen --help`를 검증합니다. API 키를 읽거나 출력하거나 업로드하지 않으며, 첫 `kyrozen` 실행에서 제공자 설정을 안내합니다.
 
 ### 개발 전용 소스 체크아웃
 
@@ -120,16 +120,17 @@ run.bat
 이 명령들은 프로젝트 모드(`--project .`)로 실행되며 저장소 개발 전용입니다.
 `make install`은 전체 `.[all]` 개발 의존성과 Chromium을 설치하므로 `make test`에서 브라우저 통합 흐름도 실행합니다. 가벼운 비브라우저 경로에는 `make install-core`와 `make test-core`를 사용하세요.
 
-### PyPI 패키지 설치
+### 고정된 GitHub 릴리스 설치
 
 ```bash
-uv tool install 'openkyrozen[web]'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+uv tool install --python 3.12 --force --with fastapi --with uvicorn "$release_url"
 
 # 이미 지원되는 Python 환경에서는 다음도 사용할 수 있습니다:
-pip install 'openkyrozen[web]'
+pip install fastapi uvicorn "$release_url"
 ```
 
-설치 후에는 어떤 호출 디렉터리에서도 `kyrozen`과 `kyrozen-web`을 실행할 수 있습니다. 암호화된 제공자 설정은 `~/.kyrozen_config.json`에 저장됩니다.
+GitHub Actions가 릴리스 wheel을 빌드하고 검증합니다. 자세한 내용은 [v2.0.1 릴리스](https://github.com/EvanProgramming/OpenKyrozen/releases/tag/v2.0.1)를 참조하세요. 설치 후에는 어떤 호출 디렉터리에서도 `kyrozen`과 `kyrozen-web`을 실행할 수 있습니다. 암호화된 제공자 설정은 `~/.kyrozen_config.json`에 저장됩니다.
 
 ---
 
@@ -170,7 +171,7 @@ Kyrozen의 동작:
 | `/api_key` | API 키 변경 |
 | `/learn` | 프로젝트 파일을 즉시 메모리에 스캔 |
 | `/forget` | 최근 학습 확인; `/forget 키워드`로 잘못된 학습 삭제 |
-| `/update` | `uv tool upgrade openkyrozen`으로 설치된 패키지 업데이트 (프로젝트에 git pull을 실행하지 않음) |
+| `/update` | 고정된 GitHub `v2.0.1` 릴리스 wheel을 다시 설치 (프로젝트에 git pull을 실행하지 않음) |
 | `/self-learning` | 개별 자기 학습 기능 켜기/끄기 |
 
 ### Web UI 모드
@@ -442,7 +443,8 @@ curl -sS -X DELETE http://127.0.0.1:8000/api/v2/memory/claims/<claim_id>
 ## 🌐 Web UI 및 REST API
 
 ```bash
-pip install 'openkyrozen[web]'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+pip install fastapi uvicorn "$release_url"
 kyrozen-web --port 8000
 # http://localhost:8000 열기
 
@@ -656,15 +658,18 @@ GitHub Actions가 모든 푸시와 PR에서 자동 실행:
 - Windows PowerShell 설치 프로그램 구문 및 도움말 경로 확인
 - Docker 빌드 및 컨테이너 교체 복구 스모크 테스트
 
-`v*` 태그를 푸시하면 sdist/wheel을 빌드하고 검증한 뒤, 설정된 `pypi`
-환경 게이트를 통과하면 GitHub Trusted Publishing으로 PyPI에 게시합니다.
+`v2.0.1` 태그를 푸시하면 sdist/wheel을 빌드하고 검증한 뒤, 아티팩트가 포함된
+GitHub Release를 만들고 Windows에서 PowerShell 설치 프로그램을 검증합니다.
+공개 설치 프로그램과 `/update`는 향후 버전을 의도적으로 게시할 때까지 이 릴리스에
+고정됩니다.
 
-### pip 패키지
+### 릴리스 wheel
 
 ```bash
-# 공개 패키지 (설치 프로그램이 uv와 Python 설정도 처리합니다)
-uv tool install 'openkyrozen[web]'
-pip install 'openkyrozen[web]'
+# 변경할 수 없는 GitHub 릴리스 (설치 프로그램이 uv와 Python 설정도 처리합니다)
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+uv tool install --python 3.12 --force --with fastapi --with uvicorn "$release_url"
+pip install fastapi uvicorn "$release_url"
 
 # 로컬 체크아웃 전용 (개발)
 pip install .                   # 코어 + CLI
@@ -693,7 +698,7 @@ OpenKyrozen/
 ├── prompts/             # 프롬프트 템플릿 (역할, 지침, 예시)
 ├── docs/tool-inventory.md # 생성된 런타임 도구/경로 인벤토리
 ├── scripts/              # 재현 가능한 문서/스모크 검사
-└── .github/workflows/   # CI, 릴리스 및 PyPI 게시 파이프라인
+└── .github/workflows/   # CI 및 태그 기반 GitHub 릴리스 파이프라인
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -91,16 +91,16 @@ Think of it as an AI teammate that gets smarter every time you use it.
 On macOS or Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/install.sh | sh
 ```
 
 On Windows PowerShell:
 
 ```powershell
-irm https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/install.ps1 | iex
 ```
 
-The installer checks the operating system, architecture, Python, network, and writable user paths; installs `uv` when needed; installs `openkyrozen[web]` in an isolated `uv` tool environment; creates private `~/.kyrozen` state directories; and verifies `kyrozen --version` and `kyrozen --help`. It never reads, prints, or uploads API keys. The first `kyrozen` launch guides provider setup.
+The installer fetches the immutable `v2.0.1` GitHub release wheel, checks the operating system, architecture, Python, network, and writable user paths; installs `uv` when needed; provisions the Web dependencies in an isolated `uv` tool environment; creates private `~/.kyrozen` state directories; and verifies `kyrozen --version` and `kyrozen --help`. It never reads, prints, or uploads API keys. The first `kyrozen` launch guides provider setup.
 
 ### Development-only source checkout
 
@@ -121,16 +121,17 @@ run.bat
 These commands intentionally run in project mode (`--project .`) and are for repository development.
 `make install` installs the full `.[all]` development set and Chromium, so `make test` also runs the browser integration flow. For a lightweight non-browser path, use `make install-core` followed by `make test-core`.
 
-### Package installation from PyPI
+### Pinned GitHub release installation
 
 ```bash
-uv tool install 'openkyrozen[web]'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+uv tool install --python 3.12 --force --with fastapi --with uvicorn "$release_url"
 
 # Or use pip in an existing supported environment:
-pip install 'openkyrozen[web]'
+pip install fastapi uvicorn "$release_url"
 ```
 
-After installation, `kyrozen` and `kyrozen-web` work from any caller directory. The encrypted provider configuration is saved to `~/.kyrozen_config.json`.
+The release wheel is built and validated by GitHub Actions; see the [v2.0.1 release](https://github.com/EvanProgramming/OpenKyrozen/releases/tag/v2.0.1). After installation, `kyrozen` and `kyrozen-web` work from any caller directory. The encrypted provider configuration is saved to `~/.kyrozen_config.json`.
 
 ---
 
@@ -171,7 +172,7 @@ Kyrozen will:
 | `/api_key` | Change your API key |
 | `/learn` | Immediately scan project files into memory |
 | `/forget` | Show recent learnings; `/forget keyword` to delete bad learnings |
-| `/update` | Upgrade the installed package with `uv tool upgrade openkyrozen` (never pulls into a project) |
+| `/update` | Reinstall the pinned `v2.0.1` GitHub release wheel (never pulls into a project) |
 | `/agent auto\|coder\|researcher` | Choose automatic routing or an isolated learning profile |
 | `/learning status [profile]` | Show candidate, canary, active, retired, and rolled-back artifacts |
 | `/learning metrics [profile]` | Show verified completion, corrections, errors, cost, and latency metrics |
@@ -595,7 +596,8 @@ with the same provider, model, configuration, and observable product behavior.
 ## 🌐 Web UI & REST API
 
 ```bash
-pip install 'openkyrozen[web]'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+pip install fastapi uvicorn "$release_url"
 kyrozen-web --port 8000
 # Open http://localhost:8000
 
@@ -655,7 +657,7 @@ KYROZEN_SERVER_TOKEN=change-me kyrozen-web --host 0.0.0.0 --port 8000
 
 Browser tools (`browser_open`, `browser_snapshot`, `browser_click`, `browser_type`, and
 `browser_close`) use an isolated profile and are available after
-`pip install 'openkyrozen[browser]' && playwright install chromium`. Private and
+`pip install playwright https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl && playwright install chromium`. Private and
 loopback destinations are blocked unless `KYROZEN_BROWSER_ALLOW_PRIVATE=1` is set.
 
 Successful `POST /api/chat` requests emit one `chat.completed` webhook after
@@ -913,16 +915,18 @@ GitHub Actions automatically runs on every push and PR:
 - Windows PowerShell installer syntax/help check
 - Docker build and replace-container recovery smoke test
 
-A `v*` tag additionally builds and validates sdist/wheel distributions, then
-publishes them to PyPI through GitHub Trusted Publishing after the configured
-`pypi` environment gate.
+A `v2.0.1` tag additionally builds and validates sdist/wheel distributions,
+creates an immutable GitHub Release with the artifacts, and verifies the
+PowerShell installer on Windows. Public installers and `/update` stay pinned
+to that release until a future version is deliberately published.
 
-### pip package
+### Release wheel
 
 ```bash
-# Published package (use the one-line installer for uv + Python setup)
-uv tool install 'openkyrozen[web]'
-pip install 'openkyrozen[web]'  # existing supported environment
+# Immutable GitHub release (use the one-line installer for uv + Python setup)
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+uv tool install --python 3.12 --force --with fastapi --with uvicorn "$release_url"
+pip install fastapi uvicorn "$release_url"  # existing supported environment
 
 # Local checkout only (development)
 pip install .
@@ -953,7 +957,7 @@ OpenKyrozen/
 ├── prompts/             # Prompt templates (role, instructions, examples)
 ├── docs/tool-inventory.md # Generated runtime tool and endpoint inventory
 ├── scripts/              # Reproducible documentation and smoke checks
-└── .github/workflows/   # CI, release, and PyPI publishing pipelines
+└── .github/workflows/   # CI and tagged GitHub-release pipelines
 ```
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -90,16 +90,16 @@ OpenKyrozen 是一款在终端中运行的**自学习 AI 智能体**。与普通
 macOS 或 Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/install.sh | sh
 ```
 
 Windows PowerShell：
 
 ```powershell
-irm https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/main/install.ps1 | iex
+irm https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/install.ps1 | iex
 ```
 
-安装器会检查操作系统、架构、Python、网络和用户目录权限；需要时安装 `uv`；在隔离的 `uv` 工具环境中安装 `openkyrozen[web]`；创建私有 `~/.kyrozen` 状态目录；并验证 `kyrozen --version` 与 `kyrozen --help`。安装器不会读取、打印或上传 API 密钥，首次运行 `kyrozen` 时再引导服务商配置。
+安装器会获取不可变的 GitHub `v2.0.1` 发布 wheel，检查操作系统、架构、Python、网络和用户目录权限；需要时安装 `uv`；在隔离的 `uv` 工具环境中配置 Web 依赖；创建私有 `~/.kyrozen` 状态目录；并验证 `kyrozen --version` 与 `kyrozen --help`。安装器不会读取、打印或上传 API 密钥，首次运行 `kyrozen` 时再引导服务商配置。
 
 ### 仅用于开发的源码检出
 
@@ -120,16 +120,17 @@ run.bat
 这些命令会显式使用项目模式（`--project .`），仅用于仓库开发。
 `make install` 会安装完整的 `.[all]` 开发依赖和 Chromium，因此 `make test` 也会运行浏览器集成流程。若只需轻量的非浏览器路径，请使用 `make install-core` 和 `make test-core`。
 
-### 从 PyPI 安装
+### 从固定的 GitHub 发布版安装
 
 ```bash
-uv tool install 'openkyrozen[web]'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+uv tool install --python 3.12 --force --with fastapi --with uvicorn "$release_url"
 
 # 已有受支持的 Python 环境也可以：
-pip install 'openkyrozen[web]'
+pip install fastapi uvicorn "$release_url"
 ```
 
-安装后可在任意调用目录运行 `kyrozen` 和 `kyrozen-web`。加密的服务商配置保存在 `~/.kyrozen_config.json`。
+GitHub Actions 会构建并验证发布 wheel，详见 [v2.0.1 发布版](https://github.com/EvanProgramming/OpenKyrozen/releases/tag/v2.0.1)。安装后可在任意调用目录运行 `kyrozen` 和 `kyrozen-web`。加密的服务商配置保存在 `~/.kyrozen_config.json`。
 
 ---
 
@@ -166,7 +167,7 @@ Kyrozen 会：
 | `/api_key` | 更改 API 密钥 |
 | `/learn` | 立即扫描项目文件存入记忆 |
 | `/forget` | 查看最近的学习记录；`/forget 关键词` 删除错误学习 |
-| `/update` | 使用 `uv tool upgrade openkyrozen` 更新已安装的软件包（不会向项目执行 git pull） |
+| `/update` | 重新安装固定的 GitHub `v2.0.1` 发布 wheel（不会向项目执行 git pull） |
 | `/self-learning` | 开关各项自学习功能 |
 
 ### Web UI 模式
@@ -448,7 +449,8 @@ curl -sS -X DELETE http://127.0.0.1:8000/api/v2/memory/claims/<claim_id>
 ## 🌐 Web UI 与 REST API
 
 ```bash
-pip install 'openkyrozen[web]'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+pip install fastapi uvicorn "$release_url"
 kyrozen-web --port 8000
 # 打开 http://localhost:8000
 
@@ -503,7 +505,8 @@ KYROZEN_SERVER_TOKEN=change-me kyrozen-web --host 0.0.0.0 --port 8000
 | `POST` | `/mcp` | 模型上下文协议（JSON-RPC 2.0） |
 
 浏览器工具（`browser_open`、`browser_snapshot`、`browser_click`、`browser_type`、
-`browser_close`）使用隔离 profile。安装 `pip install 'openkyrozen[browser]' &&
+`browser_close`）使用隔离 profile。安装 `pip install playwright
+https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl &&
 playwright install chromium` 后即可使用。默认阻止内网和 loopback 地址；只有显式设置
 `KYROZEN_BROWSER_ALLOW_PRIVATE=1` 才会放开。所有 JSON Action 都使用纯字符串 `args`；MCP
 的 `tools/list` 和 `server/discover` 为允许的工具提供 `inputSchema`，并把对象参数映射回同一字符串契约。未知/未授权工具是 JSON-RPC 协议错误，工具执行失败使用 `result.isError: true`。完整清单见 [docs/tool-inventory.md](docs/tool-inventory.md)。
@@ -668,15 +671,17 @@ GitHub Actions 在每次推送和 PR 时自动运行：
 - Windows PowerShell 安装器语法和帮助路径检查
 - Docker 构建和替换容器恢复 smoke test
 
-推送 `v*` 版本标签时，还会构建并验证 sdist/wheel，并在配置好的
-`pypi` 环境门禁后通过 GitHub Trusted Publishing 发布到 PyPI。
+推送 `v2.0.1` 版本标签时，还会构建并验证 sdist/wheel，创建包含构件的
+GitHub Release，并在 Windows 上验证 PowerShell 安装器。公共安装器和
+`/update` 会固定到该版本，直到有意发布未来版本。
 
-### pip 包
+### 发布 wheel
 
 ```bash
-# 已发布的软件包（安装器会负责 uv 和 Python 设置）
-uv tool install 'openkyrozen[web]'
-pip install 'openkyrozen[web]'
+# 不可变的 GitHub 发布版（安装器会负责 uv 和 Python 设置）
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+uv tool install --python 3.12 --force --with fastapi --with uvicorn "$release_url"
+pip install fastapi uvicorn "$release_url"
 
 # 仅限本地源码检出（开发）
 pip install .                   # 核心 + CLI
@@ -705,7 +710,7 @@ OpenKyrozen/
 ├── prompts/             # 提示词模板（角色、指令、示例）
 ├── docs/tool-inventory.md # 生成的运行时工具和端点清单
 ├── scripts/              # 可复现的文档和 smoke check
-└── .github/workflows/   # CI、发布和 PyPI 流水线
+└── .github/workflows/   # CI 和带标签的 GitHub 发布流水线
 ```
 
 ---

--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **163 unittest cases**.
+Current repository test count at this snapshot: **164 unittest cases**.
 
 ## Verified surface
 

--- a/install.ps1
+++ b/install.ps1
@@ -10,9 +10,13 @@ function Fail([string]$Message) {
 }
 
 if ($Help) {
-    Write-Output "OpenKyrozen installer: installs uv, Python 3.12/3.13, and openkyrozen[web]."
+    Write-Output "OpenKyrozen installer: installs the pinned v2.0.1 GitHub release, uv, Python 3.12/3.13, and Web dependencies."
     exit 0
 }
+
+$releaseVersion = "2.0.1"
+$releaseTag = "v$releaseVersion"
+$releaseWheelUrl = "https://github.com/EvanProgramming/OpenKyrozen/releases/download/$releaseTag/openkyrozen-$releaseVersion-py3-none-any.whl"
 
 Write-Output ""
 Write-Output "  ____  ____  _____ _   _ ____  _____ _   _  ____  _   _ "
@@ -37,9 +41,9 @@ try {
 }
 
 try {
-    Invoke-WebRequest -UseBasicParsing -Uri "https://pypi.org/" -Method Head -TimeoutSec 10 | Out-Null
+    Invoke-WebRequest -UseBasicParsing -Uri $releaseWheelUrl -Method Head -TimeoutSec 20 | Out-Null
 } catch {
-    Fail "Network access to PyPI is required to install OpenKyrozen."
+    Fail "GitHub release asset is unavailable: $releaseTag"
 }
 
 $localBin = Join-Path $HOME ".local\bin"
@@ -80,8 +84,8 @@ if (-not $pythonVersion) {
     Fail "Could not install Python 3.12 or 3.13."
 }
 
-Write-Output "[INFO] Installing OpenKyrozen from PyPI with Python $pythonVersion..."
-& $uvCommand.Source tool install --python $pythonVersion --upgrade "openkyrozen[web]"
+Write-Output "[INFO] Installing OpenKyrozen $releaseTag from its immutable GitHub release with Python $pythonVersion..."
+& $uvCommand.Source tool install --python $pythonVersion --force --with fastapi --with uvicorn $releaseWheelUrl
 try { & $uvCommand.Source tool update-shell *> $null } catch { }
 
 $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
@@ -102,7 +106,11 @@ if (-not $kyrozenCommand) {
 }
 
 Write-Output "[INFO] Verifying the installation..."
-& $kyrozenCommand.Source --version
+$installedVersion = (& $kyrozenCommand.Source --version | Out-String).Trim()
+Write-Output $installedVersion
+if ($installedVersion -notmatch "OpenKyrozen $releaseVersion") {
+    Fail "Installed version does not match GitHub release $releaseTag`: $installedVersion"
+}
 & $kyrozenCommand.Source --help *> $null
 Write-Output ""
 Write-Output "Installation complete."

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,10 @@ printf '%s\n' \
   ' \____/\____/ \_____|_| \_|_|   |_____|_| \_|\____| \___/ '
 printf '%s\n\n' 'OpenKyrozen computer-native installer'
 
+release_version='2.0.1'
+release_tag="v$release_version"
+release_wheel_url="https://github.com/EvanProgramming/OpenKyrozen/releases/download/$release_tag/openkyrozen-$release_version-py3-none-any.whl"
+
 [ -n "${HOME:-}" ] || fail 'HOME is not set.'
 
 os_name="$(uname -s 2>/dev/null || true)"
@@ -31,8 +35,8 @@ esac
 command -v mkdir >/dev/null 2>&1 || fail 'mkdir is required.'
 command -v curl >/dev/null 2>&1 || fail 'curl is required to bootstrap uv.'
 [ -w "$HOME" ] || fail "User home is not writable: $HOME"
-if ! curl -fsS --max-time 10 https://pypi.org/ >/dev/null; then
-    fail 'Network access to PyPI is required to install OpenKyrozen.'
+if ! curl -fsSL --max-time 20 -o /dev/null "$release_wheel_url"; then
+    fail "GitHub release asset is unavailable: $release_tag"
 fi
 
 state_dir="$HOME/.kyrozen"
@@ -70,8 +74,9 @@ else
     fi
 fi
 
-info "Installing OpenKyrozen from PyPI with Python $python_version..."
-"$uv_bin" tool install --python "$python_version" --upgrade 'openkyrozen[web]'
+info "Installing OpenKyrozen $release_tag from its immutable GitHub release with Python $python_version..."
+"$uv_bin" tool install --python "$python_version" --force \
+  --with fastapi --with uvicorn "$release_wheel_url"
 "$uv_bin" tool update-shell >/dev/null 2>&1 || true
 
 profile=''
@@ -92,7 +97,12 @@ if [ -z "$kyrozen_bin" ]; then
 fi
 
 info 'Verifying the installation...'
-"$kyrozen_bin" --version
+installed_version="$($kyrozen_bin --version)"
+printf '%s\n' "$installed_version"
+case "$installed_version" in
+    *"OpenKyrozen $release_version"*) ;;
+    *) fail "Installed version does not match GitHub release $release_tag: $installed_version" ;;
+esac
 "$kyrozen_bin" --help >/dev/null
 
 printf '%s\n' '' 'Installation complete.' \

--- a/main.py
+++ b/main.py
@@ -115,10 +115,17 @@ from providers import (
     save_provider_config_encrypted, encrypt_api_key, decrypt_api_key,
 )
 
+RELEASE_VERSION = "2.0.1"
+RELEASE_TAG = f"v{RELEASE_VERSION}"
+RELEASE_WHEEL_URL = (
+    "https://github.com/EvanProgramming/OpenKyrozen/releases/download/"
+    f"{RELEASE_TAG}/openkyrozen-{RELEASE_VERSION}-py3-none-any.whl"
+)
+
 try:
     __version__ = importlib.metadata.version("openkyrozen")
 except importlib.metadata.PackageNotFoundError:
-    __version__ = "2.0.0"
+    __version__ = RELEASE_VERSION
 
 # aliases for flexible action recognition
 TOOL_ALIASES: dict[str, str] = {
@@ -1230,12 +1237,17 @@ def _self_update() -> str:
     """Upgrade the installed package without touching the active project."""
     if shutil.which("uv") is None:
         return (
-            "OpenKyrozen is package-managed. Install or update it with the official installer, "
-            "or install uv and run: uv tool upgrade openkyrozen"
+            "OpenKyrozen is package-managed. Install or update it with the official "
+            f"{RELEASE_TAG} installer (uv is required)."
         )
+    requested_python = (
+        f"{sys.version_info.major}.{sys.version_info.minor}"
+        if sys.version_info[:2] in {(3, 12), (3, 13)} else "3.12"
+    )
     try:
         result = subprocess.run(
-            ["uv", "tool", "upgrade", "openkyrozen"],
+            ["uv", "tool", "install", "--python", requested_python, "--force",
+             "--with", "fastapi", "--with", "uvicorn", RELEASE_WHEEL_URL],
             capture_output=True,
             text=True,
             timeout=60,
@@ -1244,11 +1256,11 @@ def _self_update() -> str:
         err = result.stderr.strip() or ""
         if result.returncode != 0:
             return f"Update failed:\n{err}"
-        return f"Updated OpenKyrozen successfully:\n{out}"
+        return f"Updated OpenKyrozen from GitHub release {RELEASE_TAG}:\n{out}"
     except subprocess.TimeoutExpired:
         return "Update timed out."
     except FileNotFoundError:
-        return "Error: uv is not installed or could not upgrade the OpenKyrozen tool."
+        return "Error: uv is not installed or could not install the pinned OpenKyrozen release."
     except Exception as e:
         return f"Error during update: {e}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openkyrozen"
-version = "2.0.0"
+version = "2.0.1"
 description = "Self-learning AI Agent — DeepSeek · OpenAI · Claude · Gemini · Ollama"
 readme = "README.md"
 license = {text = "MIT"}

--- a/server.py
+++ b/server.py
@@ -55,7 +55,7 @@ except ImportError:
 app = FastAPI(
     title="OpenKyrozen API",
     description="Self-learning AI Agent — REST API + Web Chat",
-    version="2.0.0",
+    version=_agent.RELEASE_VERSION,
 )
 
 # ---------------------------------------------------------------------------

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -20,6 +20,7 @@ class DistributionTests(unittest.TestCase):
         with (ROOT / "pyproject.toml").open("rb") as handle:
             document = tomllib.load(handle)
         project = document["project"]
+        self.assertEqual(project["version"], "2.0.1")
         self.assertEqual(project["requires-python"], ">=3.12,<3.14")
         self.assertEqual(project["scripts"]["kyrozen"], "main:main")
         self.assertEqual(project["scripts"]["kyrozen-web"], "server:main_entry")
@@ -43,6 +44,26 @@ class DistributionTests(unittest.TestCase):
         self.assertIn("make test PYTHON=python", workflow)
         self.assertIn("make install-core PYTHON=python", workflow)
         self.assertIn("make test-core", workflow)
+        release = (ROOT / ".github" / "workflows" / "publish.yml").read_text(encoding="utf-8")
+        self.assertIn('- "v2.0.1"', release)
+        self.assertIn("python -m build --sdist --wheel", release)
+        self.assertIn("gh release create", release)
+        self.assertIn("--verify-tag", release)
+        self.assertIn("runs-on: windows-latest", release)
+        self.assertNotIn("pypa/gh-action-pypi-publish", release)
+
+    def test_public_install_paths_pin_the_verified_release(self):
+        release_url = (
+            "https://github.com/EvanProgramming/OpenKyrozen/releases/download/"
+            "v2.0.1/openkyrozen-2.0.1-py3-none-any.whl"
+        )
+        for readme in sorted(ROOT.glob("README*.md")):
+            text = readme.read_text(encoding="utf-8")
+            with self.subTest(readme=readme.name):
+                self.assertIn("raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/", text)
+                self.assertIn(release_url, text)
+                self.assertNotIn("pypi.org", text.lower())
+                self.assertNotIn("uv tool upgrade openkyrozen", text)
 
     def test_posix_installer_has_valid_syntax_and_idempotent_user_path_logic(self):
         installer = ROOT / "install.sh"
@@ -57,7 +78,11 @@ class DistributionTests(unittest.TestCase):
         self.assertIn('PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"', text)
         self.assertIn("grep -Fq '$HOME/.local/bin'", text)
         self.assertIn('tool install --python', text)
-        self.assertIn("kyrozen_bin\" --version", text)
+        self.assertIn("release_version='2.0.1'", text)
+        self.assertIn("releases/download", text)
+        self.assertIn("--with fastapi --with uvicorn", text)
+        self.assertNotIn("pypi.org", text)
+        self.assertIn("installed_version=", text)
 
     def test_powershell_installer_is_static_safe_and_parses_when_available(self):
         installer = ROOT / "install.ps1"
@@ -65,6 +90,10 @@ class DistributionTests(unittest.TestCase):
         self.assertIn("[Environment]::GetEnvironmentVariable(\"Path\", \"User\")", text)
         self.assertIn("SetEnvironmentVariable(\"Path\"", text)
         self.assertIn("tool install --python", text)
+        self.assertIn("v2.0.1", text)
+        self.assertIn("releases/download", text)
+        self.assertIn("--with fastapi --with uvicorn", text)
+        self.assertNotIn("pypi.org", text)
         powershell = shutil.which("pwsh") or shutil.which("powershell")
         if powershell is None:
             return
@@ -96,6 +125,9 @@ class DistributionTests(unittest.TestCase):
                     self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
                     self.assertIn(marker, result.stdout)
 
+        import server
+        self.assertEqual(server.app.version, "2.0.1")
+
     def test_web_parser_accepts_project_and_server_flags(self):
         import server
 
@@ -122,16 +154,22 @@ class DistributionTests(unittest.TestCase):
         import main
 
         completed = subprocess.CompletedProcess(
-            ["uv", "tool", "upgrade", "openkyrozen"], 0, stdout="upgraded", stderr="",
+            ["uv", "tool", "install"], 0, stdout="upgraded", stderr="",
         )
         with patch("main.shutil.which", return_value="/usr/local/bin/uv"), \
              patch("main.subprocess.run", return_value=completed) as run:
             result = main._self_update()
         self.assertIn("upgraded", result)
-        run.assert_called_once_with(
-            ["uv", "tool", "upgrade", "openkyrozen"],
-            capture_output=True, text=True, timeout=60,
+        command = run.call_args.args[0]
+        expected_python = (
+            f"{sys.version_info.major}.{sys.version_info.minor}"
+            if sys.version_info[:2] in {(3, 12), (3, 13)} else "3.12"
         )
+        self.assertEqual(command[:6], ["uv", "tool", "install", "--python", expected_python, "--force"])
+        self.assertIn("--with", command)
+        self.assertIn("fastapi", command)
+        self.assertIn("uvicorn", command)
+        self.assertTrue(command[-1].endswith("/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl"))
 
     def test_docker_starts_server_in_explicit_project_mode(self):
         dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- publish the repaired 2.0.1 wheel and sdist from the exact `v2.0.1` tag as a GitHub Release
- pin the POSIX and PowerShell installers, `/update`, and all four README install paths to that release
- provision Web dependencies explicitly and verify the installed version and API metadata
- add Windows installer verification to the release workflow and regression coverage for public provenance

Fixes #73

## Validation
- `make check`
- `make lint`
- `make docs-check`
- `make shell-check`
- `make test` (164 tests)
- `make wheel-smoke`
- exact local `uv tool install --python 3.12 --force --with fastapi --with uvicorn` wheel smoke from an unrelated directory
- `git diff --check`
