### PR TITLE
fix: preserve PowerShell installer help switch

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,5 +1,6 @@
 param(
-    [switch]$Help
+    [Alias("Help")]
+    [switch]$ShowHelp
 )
 
 $ErrorActionPreference = "Stop"
@@ -9,7 +10,7 @@ function Fail([string]$Message) {
     exit 1
 }
 
-if ($Help) {
+if ($ShowHelp) {
     Write-Output "OpenKyrozen installer: installs the pinned v2.0.1 GitHub release, uv, Python 3.12/3.13, and Web dependencies."
     exit 0
 }

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -87,6 +87,8 @@ class DistributionTests(unittest.TestCase):
     def test_powershell_installer_is_static_safe_and_parses_when_available(self):
         installer = ROOT / "install.ps1"
         text = installer.read_text(encoding="utf-8")
+        self.assertIn('[Alias("Help")]', text)
+        self.assertIn("$ShowHelp", text)
         self.assertIn("[Environment]::GetEnvironmentVariable(\"Path\", \"User\")", text)
         self.assertIn("SetEnvironmentVariable(\"Path\"", text)
         self.assertIn("tool install --python", text)


### PR DESCRIPTION
## Summary
- avoid PowerShell's optimized `$Help` variable collision with the uv bootstrap script
- preserve the documented `-Help` flag through a `ShowHelp` switch alias
- add regression coverage for the reserved-variable boundary

Follow-up to #101 (Fixes #73)

## Validation
- `python -m unittest tests.test_distribution -v`
- `git diff --check`
- the prior tag workflow failure is reproduced in the Windows job log and is addressed at the installer root cause
