### PR TITLE
fix: honor isolated PowerShell home

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -18,6 +18,7 @@ if ($ShowHelp) {
 $releaseVersion = "2.0.1"
 $releaseTag = "v$releaseVersion"
 $releaseWheelUrl = "https://github.com/EvanProgramming/OpenKyrozen/releases/download/$releaseTag/openkyrozen-$releaseVersion-py3-none-any.whl"
+$homeDirectory = if ($env:HOME) { $env:HOME } else { $env:USERPROFILE }
 
 Write-Output ""
 Write-Output "  ____  ____  _____ _   _ ____  _____ _   _  ____  _   _ "
@@ -33,7 +34,7 @@ if ($architecture -notin @("X64", "Arm64")) {
     Fail "Unsupported Windows architecture: $architecture"
 }
 
-$stateDir = Join-Path $HOME ".kyrozen"
+$stateDir = Join-Path $homeDirectory ".kyrozen"
 try {
     New-Item -ItemType Directory -Force -Path (Join-Path $stateDir "workspace") | Out-Null
     New-Item -ItemType Directory -Force -Path (Join-Path $stateDir "v2") | Out-Null
@@ -47,8 +48,8 @@ try {
     Fail "GitHub release asset is unavailable: $releaseTag"
 }
 
-$localBin = Join-Path $HOME ".local\bin"
-$cargoBin = Join-Path $HOME ".cargo\bin"
+$localBin = Join-Path $homeDirectory ".local\bin"
+$cargoBin = Join-Path $homeDirectory ".cargo\bin"
 $env:Path = "$localBin;$cargoBin;$env:Path"
 
 $uvCommand = Get-Command uv -ErrorAction SilentlyContinue

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -89,6 +89,8 @@ class DistributionTests(unittest.TestCase):
         text = installer.read_text(encoding="utf-8")
         self.assertIn('[Alias("Help")]', text)
         self.assertIn("$ShowHelp", text)
+        self.assertIn("$homeDirectory = if ($env:HOME)", text)
+        self.assertNotIn('Join-Path $HOME ".kyrozen"', text)
         self.assertIn("[Environment]::GetEnvironmentVariable(\"Path\", \"User\")", text)
         self.assertIn("SetEnvironmentVariable(\"Path\"", text)
         self.assertIn("tool install --python", text)


### PR DESCRIPTION
## Summary
- resolve the PowerShell installer home from environment variables instead of the automatic `$HOME` variable
- keep isolated release verification and uv tool bin discovery aligned on Windows
- add a regression assertion for the isolated-home boundary

Follow-up to #101 and #102 (Fixes #73)

## Validation
- `python -m unittest tests.test_distribution -v`
- `git diff --check`
- fixes the second tag-workflow failure observed in the Windows installer job
