### PR TITLE
fix: control PowerShell uv install location

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -55,6 +55,7 @@ $env:Path = "$localBin;$cargoBin;$env:Path"
 $uvCommand = Get-Command uv -ErrorAction SilentlyContinue
 if (-not $uvCommand) {
     Write-Output "[INFO] Installing uv..."
+    $env:UV_INSTALL_DIR = $localBin
     Invoke-Expression (Invoke-RestMethod https://astral.sh/uv/install.ps1)
     $env:Path = "$localBin;$cargoBin;$env:Path"
     $uvCommand = Get-Command uv -ErrorAction SilentlyContinue

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -91,6 +91,7 @@ class DistributionTests(unittest.TestCase):
         self.assertIn("$ShowHelp", text)
         self.assertIn("$homeDirectory = if ($env:HOME)", text)
         self.assertNotIn('Join-Path $HOME ".kyrozen"', text)
+        self.assertIn("$env:UV_INSTALL_DIR = $localBin", text)
         self.assertIn("[Environment]::GetEnvironmentVariable(\"Path\", \"User\")", text)
         self.assertIn("SetEnvironmentVariable(\"Path\"", text)
         self.assertIn("tool install --python", text)


### PR DESCRIPTION
## Summary
- set `UV_INSTALL_DIR` before bootstrapping uv so an isolated Windows HOME uses the same bin directory as the installer
- add regression coverage for the uv install-location contract

Follow-up to #101, #102, and #103 (Fixes #73)

## Validation
- `python -m unittest tests.test_distribution -v`
- `git diff --check`
- fixes the third tag-workflow failure observed in the Windows installer job
