### PR TITLE
fix: keep blocked task status honest

### DIFF
--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **164 unittest cases**.
+Current repository test count at this snapshot: **165 unittest cases**.
 
 ## Verified surface
 

--- a/main.py
+++ b/main.py
@@ -210,7 +210,18 @@ bg_console = Console(stderr=True)
 def _tasks_panel_height() -> int:
     if not tasks.tasks:
         return 0
-    return min(len(tasks.tasks) + 3, 12)
+    return min(len(tasks.tasks) + 4, 12)
+
+
+_TASK_STATUS_ORDER = ("succeeded", "failed", "blocked", "cancelled", "pending", "running")
+
+
+def _task_status_counts() -> dict[str, int]:
+    """Return durable task counts in a stable order for every surface."""
+    counts = {status: 0 for status in _TASK_STATUS_ORDER}
+    for task in tasks.tasks:
+        counts[canonical_status(task.get("status", "pending"))] += 1
+    return counts
 
 
 def _tasks_panel_content() -> str:
@@ -218,20 +229,42 @@ def _tasks_panel_content() -> str:
     if not tasks.tasks:
         return ""
     total = len(tasks.tasks)
-    done = sum(1 for t in tasks.tasks if is_complete(t))
+    counts = _task_status_counts()
+    done = counts["succeeded"]
     bar_w = 20
     filled = int(bar_w * done / max(total, 1))
     bar = _BAR_FILL * filled + _BAR_EMPTY * (bar_w - filled)
     lines = [f"[bold white on {_ACCENT_BG}] {_BOX_TL}{_BOX_H}{_BOX_H} TASKS [{bar}] {done}/{total} [/]"]
+    status_icons = {
+        "succeeded": _CHECK, "failed": "!", "blocked": "⚠" if _UNICODE_OK else "B",
+        "cancelled": "×", "pending": _CIRCLE, "running": _HALF,
+    }
+    status_colors = {
+        "succeeded": _SUCCESS, "failed": _ERROR, "blocked": _WARNING,
+        "cancelled": _MUTED, "pending": _WARNING, "running": _ACCENT,
+    }
+    status_line = "  ".join(
+        f"[{status_colors[status]}]{status_icons[status]} {status}={counts[status]}"
+        f"[/{status_colors[status]}]"
+        for status in _TASK_STATUS_ORDER
+    )
+    lines.append(f"[white on {_ACCENT_BG}] {_BOX_V} {status_line} [/]")
     for i, t in enumerate(tasks.tasks):
         status = canonical_status(t["status"])
-        icon = _CHECK if is_complete(t) else _CIRCLE if status == "pending" else _HALF
-        color = _SUCCESS if is_complete(t) else _WARNING if status == "pending" else _ACCENT
+        icon = status_icons[status]
+        color = status_colors[status]
         desc = t["description"][:55]
-        lines.append(f"[white on {_ACCENT_BG}] {_BOX_V} [{color}]{icon}[/{color}] [{_MUTED}]{i}[/{_MUTED}] {desc} [/]")
-    pending = sum(1 for t in tasks.tasks if not is_terminal(t))
-    if pending > 0:
-        lines.append(f"[bold white on {_ACCENT_BG}] {_BOX_BL}{_BOX_H}{_BOX_H} {pending} remaining — DO NOT STOP [/]")
+        lines.append(
+            f"[white on {_ACCENT_BG}] {_BOX_V} [{color}]{icon}[/{color}] "
+            f"[{_MUTED}]{i}[/{_MUTED}] {desc} [{color}]{status}[/{color}] [/]"
+        )
+    unfinished = counts["pending"] + counts["running"]
+    attention = counts["failed"] + counts["blocked"] + counts["cancelled"]
+    if unfinished:
+        suffix = f"; {attention} require attention" if attention else ""
+        lines.append(f"[bold white on {_ACCENT_BG}] {_BOX_BL}{_BOX_H}{_BOX_H} {unfinished} unfinished{suffix} — DO NOT STOP [/]")
+    elif attention:
+        lines.append(f"[bold white on {_ACCENT_BG}] {_BOX_BL}{_BOX_H}{_BOX_H} Tasks require attention: {attention} non-success [/]")
     else:
         lines.append(f"[bold white on {_ACCENT_BG}] {_BOX_BL}{_BOX_H}{_BOX_H} All tasks complete {_CHECK} [/]")
     return "\n".join(lines)
@@ -3778,8 +3811,15 @@ def _deterministic_tool_summary(tool_records: list[dict[str, Any]]) -> str:
         status = canonical_status(task.get("status", "pending"))
         task_lines.append(f"- {status}: {task.get('description', '')}")
     if task_lines:
-        lines.append("Tasks:")
+        lines.append("Durable task status (source of truth):")
         lines.extend(task_lines)
+        attention = [task for task in tasks.tasks if canonical_status(task.get("status", "pending")) != "succeeded"]
+        if attention:
+            lines.append("Recovery required for non-succeeded tasks:")
+            lines.extend(
+                f"- {canonical_status(task.get('status', 'pending'))}: {task.get('description', '')}"
+                for task in attention
+            )
     if not lines:
         return "I could not produce a user-facing response."
     return "I executed the requested actions.\n\n" + "\n".join(lines)
@@ -4292,10 +4332,15 @@ def _chat_turn_impl(user_input: str, clear_tasks: bool = False, profile: str | N
 
         # if there are no more tool calls, the LLM might be giving a natural reply
         if not next_tool_calls:
-            # If all tasks are already done (or none were set), accept this as final answer
-            all_done = not tasks.tasks or all(is_terminal(t) for t in tasks.tasks)
-            if all_done and not step_meta["define_tool_registered"]:
-                final_answer = (step_meta["clean"] or _deterministic_tool_summary(tool_records))
+            # Stop once every task is terminal, but only trust model prose when
+            # every durable task actually succeeded.
+            all_terminal = not tasks.tasks or all(is_terminal(t) for t in tasks.tasks)
+            all_succeeded = not tasks.tasks or all(is_complete(t) for t in tasks.tasks)
+            if all_terminal and not step_meta["define_tool_registered"]:
+                final_answer = (
+                    step_meta["clean"] if all_succeeded and step_meta["clean"]
+                    else _deterministic_tool_summary(tool_records)
+                )
                 break
 
             # Find the next pending task to tell the LLM what to do
@@ -4440,6 +4485,13 @@ def _chat_turn_impl(user_input: str, clear_tasks: bool = False, profile: str | N
     elif len(final_answer.strip()) < 10:
         final_answer = _deterministic_tool_summary(tool_records)
 
+    # Durable task rows are authoritative.  Never let a natural-language
+    # response or generated recap claim completion when any task failed,
+    # blocked, cancelled, pending, or is still running.
+    durable_tasks_incomplete = bool(tasks.tasks) and not all(is_complete(t) for t in tasks.tasks)
+    if durable_tasks_incomplete:
+        final_answer = _deterministic_tool_summary(tool_records)
+
     elapsed = time.time() - turn_start
     _turn_cost_log.append({
         "tokens": turn_prompt_total + turn_completion_total,
@@ -4450,7 +4502,7 @@ def _chat_turn_impl(user_input: str, clear_tasks: bool = False, profile: str | N
 
     # If tasks were completed, generate a summary so the user knows what happened
     total_tools_executed = len(tool_records)
-    if total_tools_executed >= 2:
+    if total_tools_executed >= 2 and not durable_tasks_incomplete:
         summary_prompt = (
             "You just completed a multi-step task. Summarise your work below.\n\n"
             "## What was accomplished\n"

--- a/tests/test_task_consistency.py
+++ b/tests/test_task_consistency.py
@@ -73,6 +73,63 @@ class TaskConsistencyTests(unittest.TestCase):
             self.assertIn("✓ legacy complete", hint)
             self.assertIn("✓ durable complete", hint)
 
+    def test_blocked_tasks_are_visible_and_cannot_be_summarised_as_complete(self):
+        class StubLearning:
+            def feedback_signal(self, _text):
+                return None
+
+            def route_profile(self, _text, _profile=None):
+                return "coder"
+
+            def begin_run(self, profile, _task, provider_model=None):
+                return {"run_id": "blocked-run", "profile": profile, "provider_model": provider_model}
+
+            def artifact_context(self, _run):
+                return "", []
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            store = MemoryBank(root / "state.sqlite3").store
+            manager = TaskManager(store, workspace_id="project", session_id="blocked-test")
+            index = manager.add_task("reconcile the four actions")
+            manager.set_status(index, "blocked")
+            original_root = main._get_workspace_root()
+            original_tasks = main.tasks
+            original_learning = main.learning_engine
+            main._set_workspace_root(root)
+            main.tasks = manager
+            main.learning_engine = StubLearning()
+            try:
+                panel = main._tasks_panel_content()
+                self.assertIn("blocked=1", panel)
+                self.assertIn("Tasks require attention", panel)
+                self.assertNotIn("All tasks complete", panel)
+                with patch.object(main, "_classify_complexity", return_value="simple"), \
+                     patch.object(main, "_build_messages", return_value=[]), \
+                     patch.object(main, "_build_memory_context", return_value=""), \
+                     patch.object(main, "_call_llm_with_spinner", side_effect=[
+                         'Action: {"action":"read_file","args":"first.txt"}\n'
+                         'Action: {"action":"read_file","args":"second.txt"}',
+                         "All requested file and Git operations completed.",
+                     ]), \
+                     patch.object(main, "_get_llm_response", return_value="All requested file and Git operations completed."), \
+                     patch.object(main, "_update_tasks_panel"), \
+                     patch.object(main, "_finish_learning_run", side_effect=lambda run, receipts, task,
+                                  result, records, tokens, started: result):
+                    reply = main._chat_turn("continue the work", clear_tasks=False)
+            finally:
+                main._set_workspace_root(original_root)
+                main.tasks = original_tasks
+                main.learning_engine = original_learning
+
+            self.assertIn("blocked", reply.lower())
+            self.assertIn("Recovery required", reply)
+            self.assertNotIn("All requested file and Git operations completed.", reply)
+            self.assertEqual(
+                store.list_tasks(workspace_id="project", session_id="blocked-test")[0]["status"],
+                "blocked",
+            )
+
     def test_chat_turn_executes_multiple_real_tools_and_returns_latest_prose(self):
         class StubLearning:
             def feedback_signal(self, _text):


### PR DESCRIPTION
## Summary
- render each durable task status with its own count, icon, and label
- make blocked/failed/cancelled task outcomes visible instead of claiming completion
- force final summaries to follow durable task state, with recovery-required details

## Validation
- `venv/bin/python -m unittest tests.test_task_consistency -v`
- `git diff --check`

Fixes #105