### PR TITLE
fix: authenticate protected web sessions

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -461,6 +461,8 @@ KYROZEN_SERVER_TOKEN=change-me kyrozen-web --host 0.0.0.0 --port 8000
 | メソッド | エンドポイント | 説明 |
 |--------|-------------|------|
 | `GET` | `/` | ダークテーマのチャット Web UI |
+| `POST` | `/api/auth/session` | サーバートークンを短期 HttpOnly ブラウザセッションへ交換 |
+| `DELETE` | `/api/auth/session` | 現在のブラウザセッションを無効化 |
 | `POST` | `/api/chat` | メッセージを送り、メモリ receipt 付き JSON レスポンスを取得 |
 | `POST` | `/api/chat/stream` | SSE ストリーミング；`[DONE]` 後だけ完了 webhook を送信 |
 | `GET` | `/api/memory?q=キーワード` | 保存されたメモリを検索 |
@@ -504,6 +506,9 @@ KYROZEN_SERVER_TOKEN=change-me kyrozen-web --host 0.0.0.0 --port 8000
 
 すべての JSON Action はプレーン文字列 `args` を使います。MCP の `tools/list` と
 `server/discover` は許可された各ツールの `inputSchema` を返し、object 引数を同じ文字列契約に明示的に変換します。未知/未許可ツールは JSON-RPC protocol error、実行後のツール失敗は `result.isError: true` です。完全な清書済み一覧は [docs/tool-inventory.md](docs/tool-inventory.md) を参照してください。
+
+トークン保護された Web UI が `401` を受けるとパスワード欄を表示します。入力したトークンは短期の
+`HttpOnly`/`SameSite=Strict` cookie に交換され、URL、HTML、ログ、ブラウザストレージには保存されません。
 
 ### Docker デプロイ
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -460,6 +460,8 @@ KYROZEN_SERVER_TOKEN=change-me kyrozen-web --host 0.0.0.0 --port 8000
 | 메서드 | 엔드포인트 | 설명 |
 |--------|----------|------|
 | `GET` | `/` | 다크 테마 채팅 Web UI |
+| `POST` | `/api/auth/session` | 서버 토큰을 단기 HttpOnly 브라우저 세션으로 교환 |
+| `DELETE` | `/api/auth/session` | 현재 브라우저 세션 취소 |
 | `POST` | `/api/chat` | 메시지를 보내고 메모리 receipt가 포함된 JSON 응답 받기 |
 | `POST` | `/api/chat/stream` | SSE 스트리밍; `[DONE]` 이후에만 완료 webhook 전송 |
 | `GET` | `/api/memory?q=키워드` | 저장된 메모리 검색 |
@@ -503,6 +505,9 @@ KYROZEN_SERVER_TOKEN=change-me kyrozen-web --host 0.0.0.0 --port 8000
 
 모든 JSON Action은 일반 문자열 `args`를 사용합니다. MCP의 `tools/list`와
 `server/discover`는 허용된 각 도구의 `inputSchema`를 반환하고 object 인자를 같은 문자열 계약으로 명시적으로 변환합니다. 알 수 없거나 권한이 없는 도구는 JSON-RPC protocol error이며, 실행된 도구의 실패는 `result.isError: true`입니다. 전체 정식 목록은 [docs/tool-inventory.md](docs/tool-inventory.md)를 참조하세요.
+
+토큰 보호 Web UI가 `401`을 받으면 암호 입력란을 표시합니다. 입력한 토큰은 단기
+`HttpOnly`/`SameSite=Strict` cookie로 교환되며 URL, HTML, 로그 또는 브라우저 저장소에는 기록되지 않습니다.
 
 ### Docker 배포
 

--- a/README.md
+++ b/README.md
@@ -610,6 +610,8 @@ KYROZEN_SERVER_TOKEN=change-me kyrozen-web --host 0.0.0.0 --port 8000
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/` | Dark-themed chat web UI |
+| `POST` | `/api/auth/session` | Exchange a server token for a short-lived HttpOnly browser session |
+| `DELETE` | `/api/auth/session` | Revoke the current browser session |
 | `POST` | `/api/chat` | Send a message with optional `profile`, `speaker`, `audience`, and `channel`; returns a memory receipt |
 | `POST` | `/api/chat/stream` | SSE streaming chat with the same optional profile and memory context |
 | `GET` | `/api/cost` | Token usage and cost summary |
@@ -676,6 +678,13 @@ non-loopback deployment must set `KYROZEN_SERVER_TOKEN` and send it as
 `workspace` profile by default; choose `full` explicitly for irreversible reset
 and dynamic tools. Authentication, capability tokens, and command safety checks
 still apply.
+
+When the shipped browser UI receives a protected-route `401`, enter the server
+token in its password field. The server exchanges it for a short-lived,
+`HttpOnly`/`SameSite=Strict` browser session cookie; the raw token is kept only
+in the form during that exchange and is never written to URLs, page markup,
+logs, or browser storage. The token must be entered again after the cookie
+expires or the browser session is cleared.
 
 The MCP endpoint supports `initialize`, `notifications/initialized`, `ping`,
 `server/discover`, `tools/list`, `tools/call`, and the legacy `chat/send`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -463,6 +463,8 @@ KYROZEN_SERVER_TOKEN=change-me kyrozen-web --host 0.0.0.0 --port 8000
 | 方法 | 端点 | 描述 |
 |------|------|------|
 | `GET` | `/` | 暗色主题聊天 Web UI |
+| `POST` | `/api/auth/session` | 将服务器令牌交换为短期 HttpOnly 浏览器会话 |
+| `DELETE` | `/api/auth/session` | 撤销当前浏览器会话 |
 | `POST` | `/api/chat` | 发送消息并返回带记忆 receipt 的 JSON 回复 |
 | `POST` | `/api/chat/stream` | SSE 流式聊天；仅在 `[DONE]` 后发送完成 webhook |
 | `GET` | `/api/memory?q=关键词` | 搜索已存储的记忆 |
@@ -515,6 +517,9 @@ API 和 MCP 路由在本机回环访问时可以不使用令牌；任何非本�
 设置 `KYROZEN_SERVER_TOKEN`，并通过 `Authorization: Bearer <token>` 或
 `X-Kyrozen-Token` 发送。MCP/Web 默认使用 `workspace` 能力，`full` 才会开放
 不可逆 Git reset 和动态 Python 工具；高影响 Git 操作仍受确认模式保护。
+
+启用令牌后，浏览器 UI 遇到 `401` 会显示密码框。输入令牌后，服务器换发短期
+`HttpOnly`/`SameSite=Strict` 会话 cookie；原始令牌只在交换请求中使用，不会写入 URL、页面、日志或浏览器存储。
 
 ### Docker 部署
 

--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **165 unittest cases**.
+Current repository test count at this snapshot: **168 unittest cases**.
 
 ## Verified surface
 

--- a/docs/tool-inventory.md
+++ b/docs/tool-inventory.md
@@ -54,6 +54,8 @@ Parameterized names are part of the contract; clients may substitute a value for
 | Method | Path |
 |---|---|
 | `GET` | `/` |
+| `DELETE` | `/api/auth/session` |
+| `POST` | `/api/auth/session` |
 | `POST` | `/api/chat` |
 | `POST` | `/api/chat/stream` |
 | `GET` | `/api/cost` |

--- a/server.py
+++ b/server.py
@@ -17,6 +17,7 @@ import copy
 import re
 import asyncio
 import queue
+import secrets
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -63,6 +64,10 @@ app = FastAPI(
 # ---------------------------------------------------------------------------
 
 _SERVER_TOKEN = os.environ.get("KYROZEN_SERVER_TOKEN", "").strip()
+_BROWSER_AUTH_COOKIE = "openkyrozen_browser_session"
+_BROWSER_AUTH_TTL_SECONDS = 3600
+_browser_auth_sessions: dict[str, float] = {}
+_browser_auth_lock = threading.RLock()
 # A server process is deliberately single-user.  The bearer token authenticates
 # access to this deployment; it is not a multi-user identity provider.  Keep
 # this actor stable across loopback/token access and token rotation so existing
@@ -72,6 +77,33 @@ _SERVER_ACTOR_ID = (_CONFIGURED_SERVER_ACTOR
                    if re.fullmatch(r"[A-Za-z0-9_.:@-]{1,64}", _CONFIGURED_SERVER_ACTOR)
                    else "local")
 _LOCAL_CLIENT_NAMES = {"localhost", "127.0.0.1", "::1", "testclient"}
+
+
+def _issue_browser_auth_session() -> str:
+    """Issue a short-lived, HttpOnly browser session without retaining the server token."""
+    now = time.time()
+    value = secrets.token_urlsafe(32)
+    with _browser_auth_lock:
+        expired = [key for key, deadline in _browser_auth_sessions.items() if deadline <= now]
+        for key in expired:
+            _browser_auth_sessions.pop(key, None)
+        _browser_auth_sessions[value] = now + _BROWSER_AUTH_TTL_SECONDS
+    return value
+
+
+def _browser_auth_session_valid(request: Request) -> bool:
+    value = request.cookies.get(_BROWSER_AUTH_COOKIE, "")
+    if not value:
+        return False
+    now = time.time()
+    with _browser_auth_lock:
+        deadline = _browser_auth_sessions.get(value)
+        if deadline is None:
+            return False
+        if deadline <= now:
+            _browser_auth_sessions.pop(value, None)
+            return False
+        return True
 
 
 def _is_loopback_client(request: Request) -> bool:
@@ -94,6 +126,8 @@ def require_api_access(request: Request) -> None:
         else:
             supplied = request.headers.get("x-kyrozen-token", "").strip()
         if hmac.compare_digest(supplied, _SERVER_TOKEN):
+            return
+        if _browser_auth_session_valid(request):
             return
         raise HTTPException(
             status_code=401,
@@ -468,6 +502,13 @@ header span{font-size:12px;color:#8b949e}
 #session-select:focus{outline:none;border-color:#00f0ff}
 #new-session{padding:7px 12px;font-size:12px}
 #session-limit{margin-left:auto}
+#auth-controls{background:#161b22;border-bottom:1px solid #30363d;padding:8px 20px;display:flex;align-items:center;gap:8px}
+#auth-controls[hidden]{display:none}
+#auth-controls label,#auth-status{font-size:12px;color:#8b949e}
+#server-token{min-width:220px;max-width:45vw;background:#0d1117;border:1px solid #30363d;border-radius:6px;color:#c9d1d9;padding:7px}
+#server-token:focus{outline:none;border-color:#00f0ff}
+#authenticate{padding:7px 12px;font-size:12px}
+#auth-status.error{color:#ff4466}
 #chat{flex:1;overflow-y:auto;padding:20px}
 .msg{margin-bottom:16px;max-width:85%}
 .msg.user{margin-left:auto}
@@ -499,6 +540,13 @@ button:disabled{opacity:.4;cursor:default}
   <button type="button" id="new-session">New conversation</button>
   <span id="session-limit" role="status"></span>
 </div>
+<div id="auth-controls" hidden>
+  <label for="server-token">Server token</label>
+  <input id="server-token" type="password" autocomplete="current-password" spellcheck="false"
+         aria-describedby="auth-status" placeholder="Enter the server token">
+  <button type="button" id="authenticate">Authenticate</button>
+  <span id="auth-status" role="alert"></span>
+</div>
 <div id="chat"></div>
 <div id="input-area">
   <textarea id="user-input" placeholder="Type your message..." rows="1" onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();sendMessage()}"></textarea>
@@ -511,6 +559,34 @@ const SESSION_LIST_LIMIT = 100;
 let sessionId = readActiveSession() || createSessionId();
 let recentSessions = [];
 let isStreaming = false;
+let authInFlight = false;
+
+class AuthRequiredError extends Error {}
+
+function showAuthPrompt(message) {
+  const controls = document.getElementById('auth-controls');
+  const status = document.getElementById('auth-status');
+  controls.hidden = false;
+  status.textContent = message || 'Authentication required. Enter the server token.';
+  status.classList.add('error');
+}
+
+function hideAuthPrompt() {
+  const controls = document.getElementById('auth-controls');
+  const status = document.getElementById('auth-status');
+  controls.hidden = true;
+  status.textContent = '';
+  status.classList.remove('error');
+}
+
+async function apiFetch(input, init = {}) {
+  const response = await fetch(input, {...init, credentials: 'same-origin'});
+  if (response.status === 401) {
+    showAuthPrompt('Authentication required. Enter the server token.');
+    throw new AuthRequiredError('Authentication required');
+  }
+  return response;
+}
 
 function createSessionId() {
   const random = window.crypto && window.crypto.randomUUID
@@ -551,7 +627,7 @@ function renderSessionList(sessions) {
 }
 
 async function refreshSessionList() {
-  const response = await fetch(`/api/v2/sessions?limit=${SESSION_LIST_LIMIT}`);
+  const response = await apiFetch(`/api/v2/sessions?limit=${SESSION_LIST_LIMIT}`);
   if (!response.ok) throw new Error('Could not load saved conversations');
   const data = await response.json();
   renderSessionList(data.sessions);
@@ -561,7 +637,7 @@ async function restoreSession(nextSessionId) {
   sessionId = nextSessionId;
   saveActiveSession();
   try {
-    const response = await fetch(`/api/v2/sessions/${encodeURIComponent(sessionId)}`);
+    const response = await apiFetch(`/api/v2/sessions/${encodeURIComponent(sessionId)}`);
     if (!response.ok) throw new Error('Could not load this conversation');
     const data = await response.json();
     const messages = Array.isArray(data.messages) ? data.messages : [];
@@ -571,7 +647,8 @@ async function restoreSession(nextSessionId) {
     document.getElementById('status').textContent = messages.length
       ? `Restored ${messages.length} saved message${messages.length === 1 ? '' : 's'}.`
       : 'No saved messages in this conversation.';
-  } catch (_) {
+  } catch (error) {
+    if (error instanceof AuthRequiredError) throw error;
     clearChat();
     document.getElementById('status').textContent = 'Could not load this conversation.';
   }
@@ -587,13 +664,67 @@ function startNewSession() {
   document.getElementById('user-input').focus();
 }
 
+async function loadCost() {
+  try {
+    const response = await apiFetch('/api/cost');
+    if (!response.ok) return;
+    const data = await response.json();
+    if (data.summary) document.getElementById('cost-display').textContent = 'Cost: ' + data.summary;
+  } catch (error) {
+    if (!(error instanceof AuthRequiredError)) {
+      document.getElementById('cost-display').textContent = '';
+    }
+  }
+}
+
 async function initialiseSessions() {
   try {
     await refreshSessionList();
     await restoreSession(sessionId);
-  } catch (_) {
+    await loadCost();
+  } catch (error) {
+    if (error instanceof AuthRequiredError) return;
     renderSessionList([]);
     document.getElementById('status').textContent = 'Could not load saved conversations.';
+  }
+}
+
+async function authenticate() {
+  if (authInFlight) return;
+  const input = document.getElementById('server-token');
+  const button = document.getElementById('authenticate');
+  const status = document.getElementById('auth-status');
+  const token = input.value.trim();
+  if (!token) {
+    showAuthPrompt('Enter the server token to continue.');
+    input.focus();
+    return;
+  }
+  authInFlight = true;
+  button.disabled = true;
+  status.classList.remove('error');
+  status.textContent = 'Authenticating…';
+  try {
+    const response = await fetch('/api/auth/session', {
+      method: 'POST', credentials: 'same-origin',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({token})
+    });
+    input.value = '';
+    if (!response.ok) {
+      showAuthPrompt(response.status === 401
+        ? 'Invalid server token. Check it and try again.'
+        : 'Authentication service unavailable. Try again.');
+      return;
+    }
+    hideAuthPrompt();
+    await initialiseSessions();
+  } catch (_) {
+    input.value = '';
+    showAuthPrompt('Authentication service unavailable. Try again.');
+  } finally {
+    authInFlight = false;
+    button.disabled = false;
   }
 }
 
@@ -626,7 +757,7 @@ async function sendMessage() {
   const contentDiv = assistantDiv.querySelector('.content');
 
   try {
-    const resp = await fetch('/api/chat/stream', {
+    const resp = await apiFetch('/api/chat/stream', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({message: msg, session_id: sessionId})
@@ -698,9 +829,11 @@ async function sendMessage() {
       document.getElementById('status').textContent = 'Incomplete stream';
     }
   } catch(e) {
-    contentDiv.textContent = 'Connection error: ' + e.message;
+    contentDiv.textContent = e instanceof AuthRequiredError
+      ? 'Authentication required. Enter the server token above.'
+      : 'Connection error: ' + e.message;
     contentDiv.classList.add('error');
-    document.getElementById('status').textContent = 'Error';
+    document.getElementById('status').textContent = e instanceof AuthRequiredError ? 'Authentication required' : 'Error';
   }
   isStreaming = false;
   btn.disabled = false;
@@ -712,12 +845,11 @@ document.getElementById('session-select').addEventListener('change', event => {
   if (!isStreaming) restoreSession(event.target.value);
 });
 document.getElementById('new-session').addEventListener('click', startNewSession);
-initialiseSessions();
-
-// Load cost on start
-fetch('/api/cost').then(r=>r.json()).then(d=>{
-  if (d.summary) document.getElementById('cost-display').textContent = 'Cost: ' + d.summary;
+document.getElementById('authenticate').addEventListener('click', authenticate);
+document.getElementById('server-token').addEventListener('keydown', event => {
+  if (event.key === 'Enter') { event.preventDefault(); authenticate(); }
 });
+initialiseSessions();
 </script>
 </body>
 </html>"""
@@ -725,6 +857,42 @@ fetch('/api/cost').then(r=>r.json()).then(d=>{
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
+
+@app.post("/api/auth/session")
+async def api_auth_session(request: Request):
+    """Exchange a user-entered server token for an HttpOnly browser session."""
+    if not _SERVER_TOKEN:
+        return {"authenticated": True}
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(400, "Invalid JSON")
+    supplied = str(body.get("token", "")).strip() if isinstance(body, dict) else ""
+    if not hmac.compare_digest(supplied, _SERVER_TOKEN):
+        _audit("AUTH_FAILURE", "browser bootstrap rejected")
+        response = JSONResponse({"detail": "Invalid server token"}, status_code=401)
+        response.headers["WWW-Authenticate"] = "Bearer"
+        return response
+    cookie = _issue_browser_auth_session()
+    response = JSONResponse({"authenticated": True})
+    response.set_cookie(
+        _BROWSER_AUTH_COOKIE, cookie, max_age=_BROWSER_AUTH_TTL_SECONDS,
+        httponly=True, secure=request.url.scheme == "https", samesite="strict", path="/",
+    )
+    return response
+
+
+@app.delete("/api/auth/session")
+async def api_auth_session_logout(request: Request):
+    """Revoke the current in-memory browser session and clear its cookie."""
+    value = request.cookies.get(_BROWSER_AUTH_COOKIE, "")
+    if value:
+        with _browser_auth_lock:
+            _browser_auth_sessions.pop(value, None)
+    response = JSONResponse({"authenticated": False})
+    response.delete_cookie(_BROWSER_AUTH_COOKIE, path="/")
+    return response
+
 
 @app.get("/", response_class=HTMLResponse)
 async def chat_page():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -457,6 +457,41 @@ print(json.dumps({
         self.assertEqual(server._get_or_create_session("single-user-test", "alice")["user_id"],
                          server._SERVER_ACTOR_ID)
 
+    def test_browser_token_bootstrap_uses_httponly_cookie_and_rejects_invalid_tokens(self):
+        original_token = server._SERVER_TOKEN
+        original_sessions = dict(server._browser_auth_sessions)
+        server._SERVER_TOKEN = "browser-test-token"
+        server._browser_auth_sessions.clear()
+        try:
+            client = TestClient(server.app)
+            self.assertEqual(client.get("/api/v2/sessions").status_code, 401)
+            invalid = client.post("/api/auth/session", json={"token": "wrong-token"})
+            self.assertEqual(invalid.status_code, 401)
+            self.assertNotIn("browser-test-token", invalid.text)
+
+            authenticated = client.post("/api/auth/session", json={"token": "browser-test-token"})
+            self.assertEqual(authenticated.status_code, 200, authenticated.text)
+            cookie = authenticated.headers.get("set-cookie", "")
+            self.assertIn("HttpOnly", cookie)
+            self.assertIn("SameSite=strict", cookie)
+            self.assertNotIn("browser-test-token", cookie)
+            self.assertEqual(client.get("/api/v2/sessions").status_code, 200)
+
+            self.assertEqual(client.delete("/api/auth/session").status_code, 200)
+            self.assertEqual(client.get("/api/v2/sessions").status_code, 401)
+        finally:
+            server._SERVER_TOKEN = original_token
+            server._browser_auth_sessions.clear()
+            server._browser_auth_sessions.update(original_sessions)
+
+    def test_browser_ui_uses_auth_bootstrap_and_cookie_credentials(self):
+        html = TestClient(server.app).get("/").text
+        self.assertIn('id="server-token"', html)
+        self.assertIn("/api/auth/session", html)
+        self.assertIn("credentials: 'same-origin'", html)
+        self.assertIn("apiFetch('/api/chat/stream'", html)
+        self.assertNotIn("localStorage.setItem('server-token'", html)
+
     def test_profile_validation(self):
         self.assertEqual(server._normalise_profile(None), "auto")
         self.assertEqual(server._normalise_profile("CODER"), "coder")

--- a/tests/test_web_auth.py
+++ b/tests/test_web_auth.py
@@ -1,0 +1,149 @@
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from event_store import EventStore
+
+
+class WebAuthBrowserTests(unittest.TestCase):
+    @staticmethod
+    def _free_port() -> int:
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            return int(sock.getsockname()[1])
+
+    @staticmethod
+    def _health(base_url: str) -> dict:
+        request = urllib.request.Request(
+            base_url + "/api/health",
+            headers={"Authorization": "Bearer browser-ui-token"},
+        )
+        with urllib.request.urlopen(request, timeout=5) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    @staticmethod
+    def _stop_server(process: subprocess.Popen) -> None:
+        if process.poll() is None:
+            process.terminate()
+            process.wait(timeout=5)
+        if process.stdout:
+            process.stdout.close()
+
+    @staticmethod
+    def _start_server(workspace: Path, database: Path, port: int) -> tuple[subprocess.Popen, str]:
+        repository = Path(__file__).parents[1]
+        environment = os.environ.copy()
+        environment.update({
+            "HOME": str(workspace / "home"),
+            "KYROZEN_DB_PATH": str(database),
+            "KYROZEN_DISABLE_VECTOR_INDEX": "1",
+            "KYROZEN_PROVIDER": "ollama",
+            "KYROZEN_BASE_URL": "http://127.0.0.1:11434/v1",
+            "KYROZEN_SERVER_TOKEN": "browser-ui-token",
+        })
+        for variable in ("KYROZEN_API_KEY", "DEEPSEEK_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+            environment.pop(variable, None)
+        process = subprocess.Popen(
+            [sys.executable, str(repository / "server.py"), "--project", str(workspace),
+             "--host", "127.0.0.1", "--port", str(port)],
+            cwd=workspace, env=environment, stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT, text=True,
+        )
+        base_url = f"http://127.0.0.1:{port}"
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                output = process.stdout.read() if process.stdout else ""
+                raise AssertionError(f"Web server exited before becoming ready: {output}")
+            try:
+                if WebAuthBrowserTests._health(base_url).get("status") in {"ok", "degraded"}:
+                    return process, base_url
+            except (OSError, urllib.error.URLError):
+                time.sleep(0.1)
+        WebAuthBrowserTests._stop_server(process)
+        raise AssertionError("Web server did not become ready")
+
+    @unittest.skipUnless(
+        os.environ.get("KYROZEN_BROWSER_TESTS") == "1",
+        "browser integration requires `make install` (Playwright and Chromium)",
+    )
+    def test_token_enabled_ui_authenticates_loads_sessions_streams_and_reports_invalid_token(self):
+        with tempfile.TemporaryDirectory(prefix="openkyrozen-web-auth-") as directory:
+            root = Path(directory)
+            workspace = root / "workspace"
+            workspace.mkdir()
+            (workspace / "home").mkdir()
+            database = root / "state.sqlite3"
+            store = EventStore(database)
+            store.append_event(
+                "session.message", {"role": "assistant", "content": "AUTH_UI_HISTORY"},
+                user_id="local", workspace_id="default", session_id="auth-ui-session",
+            )
+            process, base_url = self._start_server(workspace, database, self._free_port())
+            playwright = browser = bad_context = None
+            try:
+                from playwright.sync_api import sync_playwright
+
+                playwright = sync_playwright().start()
+                browser = playwright.chromium.launch(headless=True)
+                page = browser.new_page()
+                page.add_init_script(
+                    "localStorage.setItem('openkyrozen.active-session', 'auth-ui-session');"
+                )
+                stream_headers = {}
+
+                def stream_route(route):
+                    stream_headers.update(route.request.all_headers())
+                    route.fulfill(
+                        status=200,
+                        headers={"Content-Type": "text/event-stream"},
+                        body='data: {"chunk":"AUTH_UI_STREAM"}\n\ndata: [DONE]\n\n',
+                    )
+
+                page.route("**/api/chat/stream", stream_route)
+                page.goto(base_url, wait_until="domcontentloaded")
+                page.wait_for_function(
+                    "document.getElementById('auth-controls').hidden === false"
+                )
+                page.fill("#server-token", "browser-ui-token")
+                page.click("#authenticate")
+                page.wait_for_function("document.body.innerText.includes('AUTH_UI_HISTORY')")
+                self.assertTrue(page.locator("#auth-controls").is_hidden())
+
+                page.fill("#user-input", "stream through the authenticated UI")
+                page.click("#send-btn")
+                page.wait_for_function("document.body.innerText.includes('AUTH_UI_STREAM')")
+                page.wait_for_function("document.getElementById('status').textContent === 'Ready'")
+                self.assertIn("openkyrozen_browser_session=", stream_headers.get("cookie", ""))
+
+                bad_context = browser.new_context()
+                bad_page = bad_context.new_page()
+                bad_page.goto(base_url, wait_until="domcontentloaded")
+                bad_page.wait_for_function(
+                    "document.getElementById('auth-controls').hidden === false"
+                )
+                bad_page.fill("#server-token", "wrong-token")
+                bad_page.click("#authenticate")
+                bad_page.wait_for_function(
+                    "document.getElementById('auth-status').textContent.includes('Invalid server token')"
+                )
+            finally:
+                if bad_context is not None:
+                    bad_context.close()
+                if browser is not None:
+                    browser.close()
+                if playwright is not None:
+                    playwright.stop()
+                self._stop_server(process)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a token-to-HttpOnly SameSite browser-session bootstrap and revocation endpoint
- route session, cost, and streaming UI requests through same-origin cookie credentials
- show an accessible token prompt with actionable invalid-token recovery
- document the secure browser flow and add API plus Chromium regressions

## Validation
- `KYROZEN_BROWSER_TESTS=1 venv/bin/python -m unittest discover -s tests -p "test_*.py" -v` (168 passed)
- `make check lint docs-check shell-check`
- `git diff --check`

Fixes #106