### PR TITLE
fix: make concurrent CLI/web startup safe

### DIFF
--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **169 unittest cases**.
+Current repository test count at this snapshot: **170 unittest cases**.
 
 ## Verified surface
 

--- a/event_store.py
+++ b/event_store.py
@@ -11,6 +11,7 @@ import json
 import os
 import sqlite3
 import threading
+import time
 import uuid
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
@@ -39,18 +40,38 @@ class EventStore:
         self._initialise()
 
     @contextmanager
-    def connection(self) -> Iterator[sqlite3.Connection]:
-        connection = sqlite3.connect(str(self.path), timeout=30, isolation_level=None)
+    def connection(self, *, timeout: float = 30, busy_timeout_ms: int | None = None) -> Iterator[sqlite3.Connection]:
+        connection = sqlite3.connect(str(self.path), timeout=timeout, isolation_level=None)
         connection.row_factory = sqlite3.Row
         try:
-            connection.execute("PRAGMA busy_timeout=30000")
+            connection.execute(f"PRAGMA busy_timeout={busy_timeout_ms if busy_timeout_ms is not None else 30000}")
             connection.execute("PRAGMA foreign_keys=ON")
             yield connection
         finally:
             connection.close()
 
     def _initialise(self) -> None:
-        with self._lock, self.connection() as db:
+        # WAL mode changes take an exclusive lock.  Multiple supported entry
+        # points can import the store at the same time on a fresh HOME, so
+        # retry the idempotent schema bootstrap instead of surfacing a raw
+        # sqlite "database is locked" traceback.
+        delay = 0.05
+        for attempt in range(8):
+            try:
+                self._initialise_once()
+                return
+            except sqlite3.OperationalError as exc:
+                if "locked" not in str(exc).lower() and "busy" not in str(exc).lower():
+                    raise
+                if attempt == 7:
+                    raise RuntimeError(
+                        "OpenKyrozen state database is busy during startup; retry the command."
+                    ) from None
+                time.sleep(delay)
+                delay = min(delay * 2, 1.0)
+
+    def _initialise_once(self) -> None:
+        with self._lock, self.connection(timeout=1, busy_timeout_ms=1000) as db:
             db.execute("PRAGMA journal_mode=WAL")
             db.execute("PRAGMA synchronous=NORMAL")
             db.executescript(
@@ -216,7 +237,7 @@ class EventStore:
             existing = db.execute("SELECT version FROM schema_migrations WHERE version=?", (self.SCHEMA_VERSION,)).fetchone()
             if existing is None:
                 db.execute(
-                    "INSERT INTO schema_migrations(version, applied_at) VALUES (?, ?)",
+                    "INSERT OR IGNORE INTO schema_migrations(version, applied_at) VALUES (?, ?)",
                     (self.SCHEMA_VERSION, utc_now()),
                 )
 

--- a/tests/test_startup_cache.py
+++ b/tests/test_startup_cache.py
@@ -109,6 +109,57 @@ class StartupCacheTests(unittest.TestCase):
         )
         self._run_startup([sys.executable, "-c", script])
 
+    def test_cli_and_web_can_initialize_one_fresh_database_concurrently(self):
+        """Concurrent supported entry points must share a fresh SQLite state safely."""
+        repository = Path(__file__).parents[1].resolve()
+        with tempfile.TemporaryDirectory() as home_dir, tempfile.TemporaryDirectory() as state_dir, \
+                tempfile.TemporaryDirectory() as outside_dir:
+            env = os.environ.copy()
+            env.update({
+                "HOME": home_dir,
+                "KYROZEN_DB_PATH": str(Path(state_dir) / "concurrent.sqlite3"),
+                "KYROZEN_DISABLE_VECTOR_INDEX": "1",
+                "KYROZEN_PROVIDER": "ollama",
+                "PYTHONPATH": os.pathsep.join(
+                    part for part in (str(repository), env.get("PYTHONPATH", "")) if part
+                ),
+            })
+            for variable in _CREDENTIAL_ENV_VARS:
+                env.pop(variable, None)
+            commands = [
+                [sys.executable, str(repository / "main.py"), "--help"],
+                [sys.executable, str(repository / "server.py"), "--help"],
+            ]
+            processes = [
+                subprocess.Popen(
+                    command,
+                    cwd=outside_dir,
+                    env=env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+                for command in commands
+            ]
+            outputs = []
+            try:
+                for process in processes:
+                    stdout, stderr = process.communicate(timeout=STARTUP_TIMEOUT_SECONDS)
+                    output = stdout + stderr
+                    outputs.append(output)
+                    self.assertEqual(process.returncode, 0, output)
+            finally:
+                for process in processes:
+                    if process.poll() is None:
+                        process.kill()
+                        process.communicate()
+            combined = "\n".join(outputs)
+            self.assertNotIn("database is locked", combined.lower())
+            self.assertNotIn("traceback (most recent call last)", combined.lower())
+            database = Path(state_dir) / "concurrent.sqlite3"
+            self.assertTrue(database.is_file())
+            self.assertTrue((database.parent / "concurrent.sqlite3-wal").exists() or database.stat().st_size > 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- retry the idempotent SQLite WAL/schema bootstrap across processes with a bounded actionable failure
- make schema migration insertion race-safe
- add a CLI/web concurrent fresh-database regression

## Validation
- `./venv/bin/python -m unittest tests.test_startup_cache -v`
- `./venv/bin/python scripts/check_docs.py`
- `make test-core`
- `git diff --check`

Fixes #112