### PR TITLE
fix: reconcile multi-task execution receipts

### DIFF
--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **170 unittest cases**.
+Current repository test count at this snapshot: **171 unittest cases**.
 
 ## Verified surface
 

--- a/main.py
+++ b/main.py
@@ -3344,34 +3344,31 @@ def _execute_turn_action(action: str, args: Any, *, operation_scope: str,
 
 def _record_turn_receipt(receipt: ExecutionReceipt) -> dict[str, Any]:
     """Persist a receipt and reconcile the current planned task from verified evidence."""
-    task_id = tasks.active_task_id()
-    if task_id:
-        task = next(task for task in tasks.tasks if task["id"] == task_id)
-        checkpoint = task.get("checkpoint", {})
-        checkpoint_action = checkpoint.get("action")
-        if checkpoint_action and (
-            _operation_action(checkpoint_action) != receipt.action
-            or _operation_args(receipt.action, checkpoint.get("args", "")) != receipt.args
-        ):
-            task_id = None
-        elif not checkpoint_action:
-            tasks.update_checkpoint(task_id, {"action": receipt.action, "args": receipt.args})
     evidence = tasks.record_evidence(
-        task_id=task_id, action=receipt.action, args=receipt.args, result=receipt.result,
+        action=receipt.action, args=receipt.args, result=receipt.result,
         success=receipt.success, acceptance=receipt.acceptance, receipt_id=receipt.receipt_id,
     )
-    if task_id and receipt.success and receipt.acceptance:
+    task_id = evidence.get("task_id")
+    effective_acceptance = evidence.get("acceptance") or receipt.acceptance
+    if task_id:
+        task = next((item for item in tasks.tasks if item["id"] == task_id), None)
+        if task and not (task.get("checkpoint") or {}).get("action"):
+            tasks.update_checkpoint(task_id, {"action": receipt.action, "args": receipt.args})
+    if task_id and receipt.success and effective_acceptance:
         index = next(index for index, task in enumerate(tasks.tasks) if task["id"] == task_id)
         tasks.set_status(index, "succeeded")
+    receipt_payload = receipt.as_dict()
+    if effective_acceptance and not receipt_payload.get("acceptance"):
+        receipt_payload["acceptance"] = effective_acceptance
     tasks.store.append_event(
-        "execution.receipt", receipt.as_dict(), user_id=tasks.user_id,
+        "execution.receipt", {**receipt_payload, "task_id": task_id}, user_id=tasks.user_id,
         workspace_id=tasks.workspace_id, session_id=tasks.session_id, task_id=task_id,
     )
     result = {
         "receipt_id": receipt.receipt_id, "operation_id": receipt.operation_id,
         "action": receipt.action, "args": receipt.args, "result": receipt.result,
         "success": receipt.success, "authorized": receipt.authorized,
-        "acceptance": receipt.acceptance, "failure": receipt.failure,
+        "acceptance": effective_acceptance, "failure": receipt.failure, "task_id": task_id,
     }
     _emit_stream_event({"event": "tool_receipt", "tool_receipt": result})
     _emit_stream_event({"event": "tasks", "tasks": [

--- a/task_engine.py
+++ b/task_engine.py
@@ -26,6 +26,42 @@ def _scoped_task_id(scope_key: str, raw_task_id: str) -> str:
     return raw_task_id if raw_task_id.startswith(prefix) else f"{prefix}{_task_key(raw_task_id)}"
 
 
+_RECEIPT_ACTION_ALIASES = {
+    "status": "git_status",
+    "diff": "git_diff",
+    "log": "git_log",
+    "add": "git_add",
+    "commit": "git_commit",
+    "write": "write_file",
+    "run_command": "run_cmd",
+    "execute_terminal_command": "run_cmd",
+    "run_terminal": "run_cmd",
+    "terminal": "run_cmd",
+    "command": "run_cmd",
+    "bash": "run_cmd",
+    "shell": "run_cmd",
+    "sh": "run_cmd",
+    "cmd": "run_cmd",
+}
+_RECEIPT_ACTION_HINTS = {
+    "git_status": (
+        "git status", "repository status", "working tree", "repository state",
+        "inspect repository", "check repository", "status",
+    ),
+    "write_file": ("write file", "create", "save", "write", "file", "artifact", "generate"),
+    "git_add": ("git add", "stage", "staging", "staged", "add files", "prepare commit"),
+    "git_commit": ("git commit", "commit", "committed", "record changes", "save changes"),
+    "git_diff": ("git diff", "diff", "changes"),
+    "git_log": ("git log", "history", "log"),
+    "run_cmd": ("run command", "execute", "shell", "command"),
+}
+
+
+def _receipt_action(action: Any) -> str:
+    value = str(action or "").strip().lower()
+    return _RECEIPT_ACTION_ALIASES.get(value, value)
+
+
 def canonical_status(status: str) -> str:
     """Normalize the historical ``done`` spelling to the durable status."""
     status = str(status).strip().lower()
@@ -136,25 +172,105 @@ class TaskManager:
         evidence_items = ([evidence] if evidence else []) + self.tasks[idx].get("evidence", [])
         return any(item.get("success") is True and item.get("acceptance") for item in evidence_items)
 
+    @staticmethod
+    def _text_score(text: str, hints: tuple[str, ...]) -> int:
+        lowered = " ".join(str(text or "").lower().replace("_", " ").split())
+        score = 0
+        for hint in hints:
+            needle = " ".join(hint.lower().replace("_", " ").split())
+            if needle and needle in lowered:
+                score += 12 if " " in needle else 5
+        return score
+
+    def _receipt_match_score(self, task: dict[str, Any], action: str, args: str) -> int:
+        """Score one pending task against a canonical execution receipt."""
+        action = _receipt_action(action)
+        args = str(args or "").strip()
+        score = 0
+        checkpoint = task.get("checkpoint") or {}
+        checkpoint_action = _receipt_action(checkpoint.get("action"))
+        checkpoint_args = str(checkpoint.get("args") or "").strip()
+        if checkpoint_action:
+            if checkpoint_action != action:
+                return -1
+            if checkpoint_args and checkpoint_args != args:
+                return -1
+            score += 100
+            if checkpoint_args:
+                score += 20
+
+        for criterion in task.get("acceptance") or []:
+            if isinstance(criterion, dict):
+                criterion_action = _receipt_action(criterion.get("action"))
+                criterion_args = str(criterion.get("args") or "").strip()
+                if criterion_action:
+                    if criterion_action != action:
+                        continue
+                    score += 70
+                    if criterion_args and criterion_args == args:
+                        score += 20
+                    elif criterion_args:
+                        continue
+                criterion = criterion.get("description") or criterion.get("acceptance") or ""
+            score += self._text_score(str(criterion), (action,))
+
+        description = str(task.get("description") or "")
+        score += self._text_score(description, (action, *_RECEIPT_ACTION_HINTS.get(action, ())))
+        if args:
+            for token in args.replace("|", " ").split():
+                token = token.strip("\"'`.,:;()[]{}")
+                if len(token) >= 3 and token.lower() in description.lower():
+                    score += 8
+        return score
+
+    def _match_receipt_task(self, action: str, args: str) -> dict[str, Any] | None:
+        candidates = [
+            task for task in self.tasks
+            if canonical_status(task.get("status", "pending")) in {"pending", "running"}
+        ]
+        scored = [(self._receipt_match_score(task, action, args), task) for task in candidates]
+        scored = [(score, task) for score, task in scored if score > 0]
+        if not scored:
+            return None
+        highest = max(score for score, _task in scored)
+        matches = [task for score, task in scored if score == highest]
+        return matches[0] if len(matches) == 1 else None
+
     def record_evidence(self, *, task_id: str | None = None, action: str, result: str, success: bool,
                         acceptance: str | None = None, args: str | None = None,
                         receipt_id: str | None = None) -> dict[str, Any]:
-        item = {"action": action, "result": str(result)[:2000], "success": bool(success)}
+        canonical = _receipt_action(action)
+        normalized_args = str(args or "").strip()
+        item = {"action": canonical, "result": str(result)[:2000], "success": bool(success)}
         if task_id:
             item["task_id"] = str(task_id)
         if args:
-            item["args"] = str(args)[:1000]
+            item["args"] = normalized_args[:1000]
         if receipt_id:
             item["receipt_id"] = str(receipt_id)
         if acceptance:
             item["acceptance"] = acceptance
+        inferred = False
         targets = [task for task in self.tasks if task["id"] == str(task_id)] if task_id else []
-        # Compatibility for the old single-task caller.  With more than one
-        # task, an unaddressed receipt is intentionally not attached anywhere.
-        if not task_id and len(self.tasks) == 1:
-            targets = [self.tasks[0]]
-            item["task_id"] = targets[0]["id"]
+        if not task_id:
+            matched = self._match_receipt_task(canonical, normalized_args)
+            if matched is not None:
+                targets = [matched]
+                inferred = True
+                item["task_id"] = matched["id"]
+                if success and not acceptance:
+                    item["acceptance"] = f"verified receipt for planned action {canonical}"
+            # Compatibility for the old single-task caller.  An unmatched
+            # receipt remains evidence but cannot satisfy the task by itself.
+            elif len(self.tasks) == 1:
+                candidate = self.tasks[0]
+                checkpoint_action = _receipt_action((candidate.get("checkpoint") or {}).get("action"))
+                if not checkpoint_action or self._receipt_match_score(candidate, canonical, normalized_args) >= 0:
+                    targets = [candidate]
+                    item["task_id"] = candidate["id"]
         for task in targets:
+            if inferred and not (task.get("checkpoint") or {}).get("action"):
+                task["checkpoint"] = {"action": canonical, "args": normalized_args}
             task.setdefault("evidence", []).append(item)
             task["updated_at"] = utc_now()
             self._persist(task)

--- a/tests/test_task_consistency.py
+++ b/tests/test_task_consistency.py
@@ -1,3 +1,4 @@
+import subprocess
 import tempfile
 import time
 import unittest
@@ -242,6 +243,75 @@ class TaskConsistencyTests(unittest.TestCase):
             self.assertEqual({item["payload"]["success"] for item in receipts}, {True, False})
             self.assertIn("duplicate_operation", {item["payload"]["failure"] for item in receipts})
             self.assertIn("marker is complete", reply.lower())
+
+    def test_multi_task_plan_reconciles_receipts_without_taskdone_and_survives_restart(self):
+        class StubLearning:
+            def feedback_signal(self, _text):
+                return None
+
+            def route_profile(self, _text, _profile=None):
+                return "coder"
+
+            def begin_run(self, profile, _task, provider_model=None):
+                return {"run_id": "multi-task-run", "profile": profile, "provider_model": provider_model}
+
+            def artifact_context(self, _run):
+                return "", []
+
+        responses = [
+            "Plan:\n1. Check the repository status\n2. Create the audit file\n"
+            "3. Stage the audit file\n4. Commit the audit file\n"
+            "TaskList:\n```json\n"
+            "[{\"id\":\"status\",\"description\":\"Check the repository status\"},"
+            "{\"id\":\"write\",\"description\":\"Create the audit file\"},"
+            "{\"id\":\"stage\",\"description\":\"Stage the audit file\"},"
+            "{\"id\":\"commit\",\"description\":\"Commit the audit file\"}]\n```\n"
+            'Action: {"action":"git_status","args":"."}',
+            'Action: {"action":"write_file","args":"audit-task.txt|AUDIT_OK"}',
+            'Action: {"action":"git_add","args":"audit-task.txt"}',
+            'Action: {"action":"git_commit","args":"audit: post-merge"}',
+            "Committed audit file.",
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+            subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=root, check=True)
+            subprocess.run(["git", "config", "user.name", "OpenKyrozen Test"], cwd=root, check=True)
+            store = MemoryBank(root / "state.sqlite3").store
+            original_root = main._get_workspace_root()
+            original_tasks = main.tasks
+            original_learning = main.learning_engine
+            main._set_workspace_root(root)
+            main.tasks = TaskManager(store, workspace_id="project", session_id="multi-task")
+            main.learning_engine = StubLearning()
+            try:
+                with patch.object(main, "_classify_complexity", return_value="complex"), \
+                     patch.object(main, "_build_messages", return_value=[]), \
+                     patch.object(main, "_build_memory_context", return_value=""), \
+                     patch.object(main, "_call_llm_with_spinner", side_effect=responses), \
+                     patch.object(main, "_get_llm_response", return_value=""), \
+                     patch.object(main, "_update_tasks_panel"), \
+                     patch.object(main, "_finish_learning_run", side_effect=lambda run, receipts, task,
+                                  result, records, tokens, started: result):
+                    reply = main._chat_turn("Create the audit file and commit it with Git.", clear_tasks=True)
+            finally:
+                main._set_workspace_root(original_root)
+                main.tasks = original_tasks
+                main.learning_engine = original_learning
+
+            rows = store.list_tasks(workspace_id="project", session_id="multi-task")
+            self.assertEqual(len(rows), 4)
+            self.assertEqual({row["status"] for row in rows}, {"succeeded"})
+            self.assertTrue((root / "audit-task.txt").is_file())
+            self.assertIn("audit: post-merge", subprocess.run(
+                ["git", "log", "-1", "--pretty=%s"], cwd=root, capture_output=True, text=True, check=True,
+            ).stdout)
+            receipts = store.list_events("execution.receipt", workspace_id="project", session_id="multi-task")
+            self.assertEqual(len(receipts), 4)
+            self.assertEqual({event["task_id"] for event in receipts}, {row["id"] for row in rows})
+            self.assertIn("Committed audit file", reply)
+            reopened = TaskManager(store, workspace_id="project", session_id="multi-task")
+            self.assertEqual(reopened.recover(), [])
 
     def test_failed_operation_can_retry_and_provider_deadline_is_honest(self):
         operations: set[str] = set()


### PR DESCRIPTION
## Summary
- match durable receipts to pending tasks using canonical actions, arguments, checkpoints, acceptance criteria, and plan descriptions
- accept verified successful matches, including safe read-only actions, without requiring optional `TaskDone` syntax
- keep unmatched and checkpoint-mismatched work honest, with restart-persistence coverage for a real Git plan

## Validation
- `./venv/bin/python -m unittest tests.test_task_consistency tests.test_v2_core -v`
- `make test-core`
- `make lint`
- `make check`
- `./venv/bin/python scripts/check_docs.py`
- `git diff --check`

Fixes #110