### PR TITLE
fix: publish current immutable release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+name: Release OpenKyrozen
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build and validate the tagged release
+        run: |
+          python -m pip install --upgrade pip build twine
+          tag_version="${GITHUB_REF_NAME#v}"
+          package_version="$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')"
+          test "$tag_version" = "$package_version"
+          python -m build --sdist --wheel --outdir dist
+          python -m twine check dist/*
+
+      - name: Run source release regressions
+        run: |
+          python -m unittest \
+            tests.test_server.ServerBoundaryTests.test_browser_token_bootstrap_uses_httponly_cookie_and_rejects_invalid_tokens \
+            tests.test_task_consistency.TaskConsistencyTests.test_multi_task_plan_reconciles_receipts_without_taskdone_and_survives_restart
+
+      - name: Run clean installed-artifact smoke test
+        run: python scripts/wheel_smoke.py
+
+      - name: Create immutable GitHub release and upload artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" dist/* --verify-tag \
+            --title "OpenKyrozen $GITHUB_REF_NAME" --generate-notes
+
+  windows-installer:
+    needs: build-release
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install the tagged release with the PowerShell installer
+        shell: pwsh
+        run: |
+          $auditHome = Join-Path $env:RUNNER_TEMP "openkyrozen-release-home"
+          New-Item -ItemType Directory -Force -Path $auditHome | Out-Null
+          $env:HOME = $auditHome
+          $env:USERPROFILE = $auditHome
+          & "$PWD/install.ps1"
+          $bin = Join-Path $auditHome ".local\bin"
+          & (Join-Path $bin "kyrozen.exe") --version
+          & (Join-Path $bin "kyrozen.exe") --help *> $null
+          & (Join-Path $bin "kyrozen-web.exe") --help *> $null

--- a/README.ja.md
+++ b/README.ja.md
@@ -90,16 +90,16 @@ OpenKyrozen はターミナルで動作する**自己学習型 AI エージェ�
 macOS または Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.2/install.sh | sh
 ```
 
 Windows PowerShell：
 
 ```powershell
-irm https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/install.ps1 | iex
+irm https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.2/install.ps1 | iex
 ```
 
-インストーラーは不変の GitHub `v2.0.1` リリース wheel を取得し、OS、アーキテクチャ、Python、ネットワーク、ユーザーパスの書き込み可否を確認します。必要なら `uv` を導入し、分離された `uv` ツール環境に Web 依存関係を用意して、プライベートな `~/.kyrozen` 状態ディレクトリを作成し、`kyrozen --version` と `kyrozen --help` を検証します。API キーを読み取り、表示、アップロードすることはありません。初回の `kyrozen` 起動でプロバイダー設定を案内します。
+インストーラーは不変の GitHub `v2.0.2` リリース wheel を取得し、OS、アーキテクチャ、Python、ネットワーク、ユーザーパスの書き込み可否を確認します。必要なら `uv` を導入し、分離された `uv` ツール環境に Web 依存関係を用意して、プライベートな `~/.kyrozen` 状態ディレクトリを作成し、`kyrozen --version` と `kyrozen --help` を検証します。API キーを読み取り、表示、アップロードすることはありません。初回の `kyrozen` 起動でプロバイダー設定を案内します。
 
 ### 開発専用のソースチェックアウト
 
@@ -123,14 +123,14 @@ run.bat
 ### 固定 GitHub リリースからのインストール
 
 ```bash
-release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.2/openkyrozen-2.0.2-py3-none-any.whl'
 uv tool install --python 3.12 --force --with fastapi --with uvicorn "$release_url"
 
 # 対応済みの Python 環境ではこちらも使用できます：
 pip install fastapi uvicorn "$release_url"
 ```
 
-v2.0.1 のリリース wheel は GitHub Actions でビルド・検証済みです。詳しくは [v2.0.1 リリース](https://github.com/EvanProgramming/OpenKyrozen/releases/tag/v2.0.1) を参照してください。インストール後は任意の呼び出し元ディレクトリから `kyrozen` と `kyrozen-web` を実行できます。暗号化されたプロバイダー設定は `~/.kyrozen_config.json` に保存されます。
+v2.0.2 のリリース wheel は GitHub Actions でビルド・検証済みです。詳しくは [v2.0.2 リリース](https://github.com/EvanProgramming/OpenKyrozen/releases/tag/v2.0.2) を参照してください。インストール後は任意の呼び出し元ディレクトリから `kyrozen` と `kyrozen-web` を実行できます。暗号化されたプロバイダー設定は `~/.kyrozen_config.json` に保存されます。
 
 ---
 
@@ -171,7 +171,7 @@ Kyrozen は：
 | `/api_key` | API キーを変更 |
 | `/learn` | プロジェクトファイルを即座にメモリにスキャン |
 | `/forget` | 最近の学習を表示；`/forget キーワード` で誤った学習を削除 |
-| `/update` | 固定された GitHub `v2.0.1` リリース wheel を再インストール（プロジェクトへ git pull しない） |
+| `/update` | 固定された GitHub `v2.0.2` リリース wheel を再インストール（プロジェクトへ git pull しない） |
 | `/self-learning` | 個別の自己学習機能をオン/オフ |
 
 ### Web UI モード
@@ -444,7 +444,7 @@ curl -sS -X DELETE http://127.0.0.1:8000/api/v2/memory/claims/<claim_id>
 ## 🌐 Web UI と REST API
 
 ```bash
-release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.2/openkyrozen-2.0.2-py3-none-any.whl'
 pip install fastapi uvicorn "$release_url"
 kyrozen-web --port 8000
 # http://localhost:8000 を開く
@@ -665,7 +665,7 @@ GitHub Actions がプッシュと PR ごとに自動実行：
 - Windows PowerShell インストーラーの構文とヘルプ経路のチェック
 - Docker ビルドとコンテナ置換後の復元スモークテスト
 
-公開済みの `v2.0.1` リリースは不変であり、公開インストーラーと `/update` は
+公開済みの `v2.0.2` リリースは不変であり、公開インストーラーと `/update` は
 このリリースに固定されています。将来のリリースは意図的な手動作業として、
 固定バージョンを更新し、成果物と両方のインストーラーを検証してから新しい
 タグを公開してください。
@@ -674,7 +674,7 @@ GitHub Actions がプッシュと PR ごとに自動実行：
 
 ```bash
 # 不変の GitHub リリース（インストーラーが uv と Python の設定も行います）
-release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.2/openkyrozen-2.0.2-py3-none-any.whl'
 uv tool install --python 3.12 --force --with fastapi --with uvicorn "$release_url"
 pip install fastapi uvicorn "$release_url"
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -90,16 +90,16 @@ OpenKyrozen은 터미널에서 실행되는 **자기 학습형 AI 에이전트**
 macOS 또는 Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.2/install.sh | sh
 ```
 
 Windows PowerShell:
 
 ```powershell
-irm https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/install.ps1 | iex
+irm https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.2/install.ps1 | iex
 ```
 
-설치 프로그램은 변경할 수 없는 GitHub `v2.0.1` 릴리스 wheel을 가져와 OS, 아키텍처, Python, 네트워크와 사용자 경로 쓰기 권한을 확인합니다. 필요하면 `uv`를 설치하고, 격리된 `uv` 도구 환경에 Web 의존성을 준비하며, 비공개 `~/.kyrozen` 상태 디렉터리를 만든 뒤 `kyrozen --version`과 `kyrozen --help`를 검증합니다. API 키를 읽거나 출력하거나 업로드하지 않으며, 첫 `kyrozen` 실행에서 제공자 설정을 안내합니다.
+설치 프로그램은 변경할 수 없는 GitHub `v2.0.2` 릴리스 wheel을 가져와 OS, 아키텍처, Python, 네트워크와 사용자 경로 쓰기 권한을 확인합니다. 필요하면 `uv`를 설치하고, 격리된 `uv` 도구 환경에 Web 의존성을 준비하며, 비공개 `~/.kyrozen` 상태 디렉터리를 만든 뒤 `kyrozen --version`과 `kyrozen --help`를 검증합니다. API 키를 읽거나 출력하거나 업로드하지 않으며, 첫 `kyrozen` 실행에서 제공자 설정을 안내합니다.
 
 ### 개발 전용 소스 체크아웃
 
@@ -123,14 +123,14 @@ run.bat
 ### 고정된 GitHub 릴리스 설치
 
 ```bash
-release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.2/openkyrozen-2.0.2-py3-none-any.whl'
 uv tool install --python 3.12 --force --with fastapi --with uvicorn "$release_url"
 
 # 이미 지원되는 Python 환경에서는 다음도 사용할 수 있습니다:
 pip install fastapi uvicorn "$release_url"
 ```
 
-v2.0.1 릴리스 wheel은 GitHub Actions에서 빌드하고 검증했습니다. 자세한 내용은 [v2.0.1 릴리스](https://github.com/EvanProgramming/OpenKyrozen/releases/tag/v2.0.1)를 참조하세요. 설치 후에는 어떤 호출 디렉터리에서도 `kyrozen`과 `kyrozen-web`을 실행할 수 있습니다. 암호화된 제공자 설정은 `~/.kyrozen_config.json`에 저장됩니다.
+v2.0.2 릴리스 wheel은 GitHub Actions에서 빌드하고 검증했습니다. 자세한 내용은 [v2.0.2 릴리스](https://github.com/EvanProgramming/OpenKyrozen/releases/tag/v2.0.2)를 참조하세요. 설치 후에는 어떤 호출 디렉터리에서도 `kyrozen`과 `kyrozen-web`을 실행할 수 있습니다. 암호화된 제공자 설정은 `~/.kyrozen_config.json`에 저장됩니다.
 
 ---
 
@@ -171,7 +171,7 @@ Kyrozen의 동작:
 | `/api_key` | API 키 변경 |
 | `/learn` | 프로젝트 파일을 즉시 메모리에 스캔 |
 | `/forget` | 최근 학습 확인; `/forget 키워드`로 잘못된 학습 삭제 |
-| `/update` | 고정된 GitHub `v2.0.1` 릴리스 wheel을 다시 설치 (프로젝트에 git pull을 실행하지 않음) |
+| `/update` | 고정된 GitHub `v2.0.2` 릴리스 wheel을 다시 설치 (프로젝트에 git pull을 실행하지 않음) |
 | `/self-learning` | 개별 자기 학습 기능 켜기/끄기 |
 
 ### Web UI 모드
@@ -443,7 +443,7 @@ curl -sS -X DELETE http://127.0.0.1:8000/api/v2/memory/claims/<claim_id>
 ## 🌐 Web UI 및 REST API
 
 ```bash
-release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.2/openkyrozen-2.0.2-py3-none-any.whl'
 pip install fastapi uvicorn "$release_url"
 kyrozen-web --port 8000
 # http://localhost:8000 열기
@@ -663,7 +663,7 @@ GitHub Actions가 모든 푸시와 PR에서 자동 실행:
 - Windows PowerShell 설치 프로그램 구문 및 도움말 경로 확인
 - Docker 빌드 및 컨테이너 교체 복구 스모크 테스트
 
-게시된 `v2.0.1` 릴리스는 변경할 수 없으며 공개 설치 프로그램과 `/update`는 이
+게시된 `v2.0.2` 릴리스는 변경할 수 없으며 공개 설치 프로그램과 `/update`는 이
 릴리스에 고정됩니다. 향후 릴리스는 의도적인 수동 작업으로 진행합니다. 고정 버전을
 업데이트하고, 아티팩트와 두 설치 프로그램을 검증한 뒤 새 태그를 게시하세요.
 
@@ -671,7 +671,7 @@ GitHub Actions가 모든 푸시와 PR에서 자동 실행:
 
 ```bash
 # 변경할 수 없는 GitHub 릴리스 (설치 프로그램이 uv와 Python 설정도 처리합니다)
-release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.2/openkyrozen-2.0.2-py3-none-any.whl'
 uv tool install --python 3.12 --force --with fastapi --with uvicorn "$release_url"
 pip install fastapi uvicorn "$release_url"
 

--- a/README.md
+++ b/README.md
@@ -91,16 +91,16 @@ Think of it as an AI teammate that gets smarter every time you use it.
 On macOS or Linux:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.2/install.sh | sh
 ```
 
 On Windows PowerShell:
 
 ```powershell
-irm https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/install.ps1 | iex
+irm https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.2/install.ps1 | iex
 ```
 
-The installer fetches the immutable `v2.0.1` GitHub release wheel, checks the operating system, architecture, Python, network, and writable user paths; installs `uv` when needed; provisions the Web dependencies in an isolated `uv` tool environment; creates private `~/.kyrozen` state directories; and verifies `kyrozen --version` and `kyrozen --help`. It never reads, prints, or uploads API keys. The first `kyrozen` launch guides provider setup.
+The installer fetches the immutable `v2.0.2` GitHub release wheel, checks the operating system, architecture, Python, network, and writable user paths; installs `uv` when needed; provisions the Web dependencies in an isolated `uv` tool environment; creates private `~/.kyrozen` state directories; and verifies `kyrozen --version` and `kyrozen --help`. It never reads, prints, or uploads API keys. The first `kyrozen` launch guides provider setup.
 
 ### Development-only source checkout
 
@@ -124,14 +124,14 @@ These commands intentionally run in project mode (`--project .`) and are for rep
 ### Pinned GitHub release installation
 
 ```bash
-release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.2/openkyrozen-2.0.2-py3-none-any.whl'
 uv tool install --python 3.12 --force --with fastapi --with uvicorn "$release_url"
 
 # Or use pip in an existing supported environment:
 pip install fastapi uvicorn "$release_url"
 ```
 
-The v2.0.1 release wheel was built and validated by GitHub Actions; see the [v2.0.1 release](https://github.com/EvanProgramming/OpenKyrozen/releases/tag/v2.0.1). After installation, `kyrozen` and `kyrozen-web` work from any caller directory. The encrypted provider configuration is saved to `~/.kyrozen_config.json`.
+The v2.0.2 release wheel was built and validated by GitHub Actions; see the [v2.0.2 release](https://github.com/EvanProgramming/OpenKyrozen/releases/tag/v2.0.2). After installation, `kyrozen` and `kyrozen-web` work from any caller directory. The encrypted provider configuration is saved to `~/.kyrozen_config.json`.
 
 ---
 
@@ -172,7 +172,7 @@ Kyrozen will:
 | `/api_key` | Change your API key |
 | `/learn` | Immediately scan project files into memory |
 | `/forget` | Show recent learnings; `/forget keyword` to delete bad learnings |
-| `/update` | Reinstall the pinned `v2.0.1` GitHub release wheel (never pulls into a project) |
+| `/update` | Reinstall the pinned `v2.0.2` GitHub release wheel (never pulls into a project) |
 | `/agent auto\|coder\|researcher` | Choose automatic routing or an isolated learning profile |
 | `/learning status [profile]` | Show candidate, canary, active, retired, and rolled-back artifacts |
 | `/learning metrics [profile]` | Show verified completion, corrections, errors, cost, and latency metrics |
@@ -596,7 +596,7 @@ with the same provider, model, configuration, and observable product behavior.
 ## 🌐 Web UI & REST API
 
 ```bash
-release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.2/openkyrozen-2.0.2-py3-none-any.whl'
 pip install fastapi uvicorn "$release_url"
 kyrozen-web --port 8000
 # Open http://localhost:8000
@@ -659,7 +659,7 @@ KYROZEN_SERVER_TOKEN=change-me kyrozen-web --host 0.0.0.0 --port 8000
 
 Browser tools (`browser_open`, `browser_snapshot`, `browser_click`, `browser_type`, and
 `browser_close`) use an isolated profile and are available after
-`pip install playwright https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl && playwright install chromium`. Private and
+`pip install playwright https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.2/openkyrozen-2.0.2-py3-none-any.whl && playwright install chromium`. Private and
 loopback destinations are blocked unless `KYROZEN_BROWSER_ALLOW_PRIVATE=1` is set.
 
 Successful `POST /api/chat` requests emit one `chat.completed` webhook after
@@ -924,7 +924,7 @@ GitHub Actions automatically runs on every push and PR:
 - Windows PowerShell installer syntax/help check
 - Docker build and replace-container recovery smoke test
 
-The published `v2.0.1` release is immutable and remains the pinned target for
+The published `v2.0.2` release is immutable and remains the pinned target for
 public installers and `/update`. A future release is a deliberate, manual
 release operation: update the pinned version, build and validate the artifacts,
 and verify both installers before publishing the new tag.
@@ -933,7 +933,7 @@ and verify both installers before publishing the new tag.
 
 ```bash
 # Immutable GitHub release (use the one-line installer for uv + Python setup)
-release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.2/openkyrozen-2.0.2-py3-none-any.whl'
 uv tool install --python 3.12 --force --with fastapi --with uvicorn "$release_url"
 pip install fastapi uvicorn "$release_url"  # existing supported environment
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -90,16 +90,16 @@ OpenKyrozen 是一款在终端中运行的**自学习 AI 智能体**。与普通
 macOS 或 Linux：
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.2/install.sh | sh
 ```
 
 Windows PowerShell：
 
 ```powershell
-irm https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/install.ps1 | iex
+irm https://raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.2/install.ps1 | iex
 ```
 
-安装器会获取不可变的 GitHub `v2.0.1` 发布 wheel，检查操作系统、架构、Python、网络和用户目录权限；需要时安装 `uv`；在隔离的 `uv` 工具环境中配置 Web 依赖；创建私有 `~/.kyrozen` 状态目录；并验证 `kyrozen --version` 与 `kyrozen --help`。安装器不会读取、打印或上传 API 密钥，首次运行 `kyrozen` 时再引导服务商配置。
+安装器会获取不可变的 GitHub `v2.0.2` 发布 wheel，检查操作系统、架构、Python、网络和用户目录权限；需要时安装 `uv`；在隔离的 `uv` 工具环境中配置 Web 依赖；创建私有 `~/.kyrozen` 状态目录；并验证 `kyrozen --version` 与 `kyrozen --help`。安装器不会读取、打印或上传 API 密钥，首次运行 `kyrozen` 时再引导服务商配置。
 
 ### 仅用于开发的源码检出
 
@@ -123,14 +123,14 @@ run.bat
 ### 从固定的 GitHub 发布版安装
 
 ```bash
-release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.2/openkyrozen-2.0.2-py3-none-any.whl'
 uv tool install --python 3.12 --force --with fastapi --with uvicorn "$release_url"
 
 # 已有受支持的 Python 环境也可以：
 pip install fastapi uvicorn "$release_url"
 ```
 
-v2.0.1 发布 wheel 已由 GitHub Actions 构建并验证，详见 [v2.0.1 发布版](https://github.com/EvanProgramming/OpenKyrozen/releases/tag/v2.0.1)。安装后可在任意调用目录运行 `kyrozen` 和 `kyrozen-web`。加密的服务商配置保存在 `~/.kyrozen_config.json`。
+v2.0.2 发布 wheel 已由 GitHub Actions 构建并验证，详见 [v2.0.2 发布版](https://github.com/EvanProgramming/OpenKyrozen/releases/tag/v2.0.2)。安装后可在任意调用目录运行 `kyrozen` 和 `kyrozen-web`。加密的服务商配置保存在 `~/.kyrozen_config.json`。
 
 ---
 
@@ -167,7 +167,7 @@ Kyrozen 会：
 | `/api_key` | 更改 API 密钥 |
 | `/learn` | 立即扫描项目文件存入记忆 |
 | `/forget` | 查看最近的学习记录；`/forget 关键词` 删除错误学习 |
-| `/update` | 重新安装固定的 GitHub `v2.0.1` 发布 wheel（不会向项目执行 git pull） |
+| `/update` | 重新安装固定的 GitHub `v2.0.2` 发布 wheel（不会向项目执行 git pull） |
 | `/self-learning` | 开关各项自学习功能 |
 
 ### Web UI 模式
@@ -449,7 +449,7 @@ curl -sS -X DELETE http://127.0.0.1:8000/api/v2/memory/claims/<claim_id>
 ## 🌐 Web UI 与 REST API
 
 ```bash
-release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.2/openkyrozen-2.0.2-py3-none-any.whl'
 pip install fastapi uvicorn "$release_url"
 kyrozen-web --port 8000
 # 打开 http://localhost:8000
@@ -508,7 +508,7 @@ KYROZEN_SERVER_TOKEN=change-me kyrozen-web --host 0.0.0.0 --port 8000
 
 浏览器工具（`browser_open`、`browser_snapshot`、`browser_click`、`browser_type`、
 `browser_close`）使用隔离 profile。安装 `pip install playwright
-https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl &&
+https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.2/openkyrozen-2.0.2-py3-none-any.whl &&
 playwright install chromium` 后即可使用。默认阻止内网和 loopback 地址；只有显式设置
 `KYROZEN_BROWSER_ALLOW_PRIVATE=1` 才会放开。所有 JSON Action 都使用纯字符串 `args`；MCP
 的 `tools/list` 和 `server/discover` 为允许的工具提供 `inputSchema`，并把对象参数映射回同一字符串契约。未知/未授权工具是 JSON-RPC 协议错误，工具执行失败使用 `result.isError: true`。完整清单见 [docs/tool-inventory.md](docs/tool-inventory.md)。
@@ -676,7 +676,7 @@ GitHub Actions 在每次推送和 PR 时自动运行：
 - Windows PowerShell 安装器语法和帮助路径检查
 - Docker 构建和替换容器恢复 smoke test
 
-已发布的 `v2.0.1` 版本不可变，公共安装器和 `/update` 会固定到该版本。
+已发布的 `v2.0.2` 版本不可变，公共安装器和 `/update` 会固定到该版本。
 未来版本必须经过有意的手动发布：先更新固定版本，构建并验证构件，验证
 两个安装器，再发布新标签。
 
@@ -684,7 +684,7 @@ GitHub Actions 在每次推送和 PR 时自动运行：
 
 ```bash
 # 不可变的 GitHub 发布版（安装器会负责 uv 和 Python 设置）
-release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl'
+release_url='https://github.com/EvanProgramming/OpenKyrozen/releases/download/v2.0.2/openkyrozen-2.0.2-py3-none-any.whl'
 uv tool install --python 3.12 --force --with fastapi --with uvicorn "$release_url"
 pip install fastapi uvicorn "$release_url"
 

--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **171 unittest cases**.
+Current repository test count at this snapshot: **172 unittest cases**.
 
 ## Verified surface
 

--- a/install.ps1
+++ b/install.ps1
@@ -11,11 +11,11 @@ function Fail([string]$Message) {
 }
 
 if ($ShowHelp) {
-    Write-Output "OpenKyrozen installer: installs the pinned v2.0.1 GitHub release, uv, Python 3.12/3.13, and Web dependencies."
+    Write-Output "OpenKyrozen installer: installs the pinned v2.0.2 GitHub release, uv, Python 3.12/3.13, and Web dependencies."
     exit 0
 }
 
-$releaseVersion = "2.0.1"
+$releaseVersion = "2.0.2"
 $releaseTag = "v$releaseVersion"
 $releaseWheelUrl = "https://github.com/EvanProgramming/OpenKyrozen/releases/download/$releaseTag/openkyrozen-$releaseVersion-py3-none-any.whl"
 $homeDirectory = if ($env:HOME) { $env:HOME } else { $env:USERPROFILE }

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ printf '%s\n' \
   ' \____/\____/ \_____|_| \_|_|   |_____|_| \_|\____| \___/ '
 printf '%s\n\n' 'OpenKyrozen computer-native installer'
 
-release_version='2.0.1'
+release_version='2.0.2'
 release_tag="v$release_version"
 release_wheel_url="https://github.com/EvanProgramming/OpenKyrozen/releases/download/$release_tag/openkyrozen-$release_version-py3-none-any.whl"
 

--- a/main.py
+++ b/main.py
@@ -115,7 +115,7 @@ from providers import (
     save_provider_config_encrypted, encrypt_api_key, decrypt_api_key,
 )
 
-RELEASE_VERSION = "2.0.1"
+RELEASE_VERSION = "2.0.2"
 RELEASE_TAG = f"v{RELEASE_VERSION}"
 RELEASE_WHEEL_URL = (
     "https://github.com/EvanProgramming/OpenKyrozen/releases/download/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openkyrozen"
-version = "2.0.1"
+version = "2.0.2"
 description = "Self-learning AI Agent — DeepSeek · OpenAI · Claude · Gemini · Ollama"
 readme = "README.md"
 license = {text = "MIT"}

--- a/scripts/wheel_smoke.py
+++ b/scripts/wheel_smoke.py
@@ -53,7 +53,10 @@ def main() -> int:
         bin_dir = venv / ("Scripts" if os.name == "nt" else "bin")
         python = bin_dir / ("python.exe" if os.name == "nt" else "python")
         kyrozen = bin_dir / ("kyrozen.exe" if os.name == "nt" else "kyrozen")
-        _run([str(python), "-m", "pip", "install", str(wheels[0])], cwd=ROOT, env=base_env)
+        _run(
+            [str(python), "-m", "pip", "install", "fastapi", "uvicorn", str(wheels[0])],
+            cwd=ROOT, env=base_env,
+        )
 
         env = base_env.copy()
         env.update({
@@ -73,6 +76,34 @@ def main() -> int:
         expected_root = str((home / ".kyrozen" / "workspace").resolve())
         if "Global mode:" not in launched.stdout or expected_root not in compact_output:
             raise RuntimeError(f"installed CLI did not bind the global root:\n{launched.stdout}{launched.stderr}")
+
+        probe_code = """
+import tempfile
+from pathlib import Path
+import main
+import server
+
+assert any(r.path == "/api/auth/session" and "POST" in (r.methods or set()) for r in server.app.routes)
+from event_store import EventStore
+from task_engine import TaskManager
+
+with tempfile.TemporaryDirectory() as directory:
+    store = EventStore(Path(directory) / "state.sqlite3")
+    manager = TaskManager(store, workspace_id="smoke", session_id="release")
+    index = manager.add_task("blocked smoke task")
+    manager.set_status(index, "blocked")
+    previous = main.tasks
+    main.tasks = manager
+    try:
+        assert main._task_status_counts()["blocked"] == 1
+        assert "All tasks complete" not in main._tasks_panel_content()
+    finally:
+        main.tasks = previous
+print("installed artifact auth/task behavior passed")
+"""
+        probe = _run([str(python), "-c", probe_code], cwd=caller, env=env)
+        if "installed artifact auth/task behavior passed" not in probe.stdout:
+            raise RuntimeError(f"installed artifact behavior probe failed:\n{probe.stdout}{probe.stderr}")
 
     print("Wheel installation smoke passed: kyrozen ran from an unrelated directory.")
     return 0

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -20,7 +20,7 @@ class DistributionTests(unittest.TestCase):
         with (ROOT / "pyproject.toml").open("rb") as handle:
             document = tomllib.load(handle)
         project = document["project"]
-        self.assertEqual(project["version"], "2.0.1")
+        self.assertEqual(project["version"], "2.0.2")
         self.assertEqual(project["requires-python"], ">=3.12,<3.14")
         self.assertEqual(project["scripts"]["kyrozen"], "main:main")
         self.assertEqual(project["scripts"]["kyrozen-web"], "server:main_entry")
@@ -48,15 +48,27 @@ class DistributionTests(unittest.TestCase):
     def test_one_shot_release_workflow_is_retired_after_v2_release(self):
         self.assertFalse((ROOT / ".github" / "workflows" / "publish.yml").exists())
 
+    def test_tag_release_workflow_validates_source_and_installed_artifacts(self):
+        workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+        self.assertIn('tags:', workflow)
+        self.assertIn('test "$tag_version" = "$package_version"', workflow)
+        self.assertIn("tests.test_server.ServerBoundaryTests.test_browser_token_bootstrap", workflow)
+        self.assertIn("tests.test_task_consistency.TaskConsistencyTests.test_multi_task_plan", workflow)
+        self.assertIn("python scripts/wheel_smoke.py", workflow)
+        self.assertIn("runs-on: windows-latest", workflow)
+        smoke = (ROOT / "scripts" / "wheel_smoke.py").read_text(encoding="utf-8")
+        self.assertIn("/api/auth/session", smoke)
+        self.assertIn("_task_status_counts", smoke)
+
     def test_public_install_paths_pin_the_verified_release(self):
         release_url = (
             "https://github.com/EvanProgramming/OpenKyrozen/releases/download/"
-            "v2.0.1/openkyrozen-2.0.1-py3-none-any.whl"
+            "v2.0.2/openkyrozen-2.0.2-py3-none-any.whl"
         )
         for readme in sorted(ROOT.glob("README*.md")):
             text = readme.read_text(encoding="utf-8")
             with self.subTest(readme=readme.name):
-                self.assertIn("raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.1/", text)
+                self.assertIn("raw.githubusercontent.com/EvanProgramming/OpenKyrozen/v2.0.2/", text)
                 self.assertIn(release_url, text)
                 self.assertNotIn("pypi.org", text.lower())
                 self.assertNotIn("uv tool upgrade openkyrozen", text)
@@ -74,7 +86,7 @@ class DistributionTests(unittest.TestCase):
         self.assertIn('PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"', text)
         self.assertIn("grep -Fq '$HOME/.local/bin'", text)
         self.assertIn('tool install --python', text)
-        self.assertIn("release_version='2.0.1'", text)
+        self.assertIn("release_version='2.0.2'", text)
         self.assertIn("releases/download", text)
         self.assertIn("--with fastapi --with uvicorn", text)
         self.assertNotIn("pypi.org", text)
@@ -91,7 +103,7 @@ class DistributionTests(unittest.TestCase):
         self.assertIn("[Environment]::GetEnvironmentVariable(\"Path\", \"User\")", text)
         self.assertIn("SetEnvironmentVariable(\"Path\"", text)
         self.assertIn("tool install --python", text)
-        self.assertIn("v2.0.1", text)
+        self.assertIn("v2.0.2", text)
         self.assertIn("releases/download", text)
         self.assertIn("--with fastapi --with uvicorn", text)
         self.assertNotIn("pypi.org", text)
@@ -127,7 +139,7 @@ class DistributionTests(unittest.TestCase):
                     self.assertIn(marker, result.stdout)
 
         import server
-        self.assertEqual(server.app.version, "2.0.1")
+        self.assertEqual(server.app.version, "2.0.2")
 
     def test_web_parser_accepts_project_and_server_flags(self):
         import server
@@ -170,7 +182,7 @@ class DistributionTests(unittest.TestCase):
         self.assertIn("--with", command)
         self.assertIn("fastapi", command)
         self.assertIn("uvicorn", command)
-        self.assertTrue(command[-1].endswith("/v2.0.1/openkyrozen-2.0.1-py3-none-any.whl"))
+        self.assertTrue(command[-1].endswith("/v2.0.2/openkyrozen-2.0.2-py3-none-any.whl"))
 
     def test_docker_starts_server_in_explicit_project_mode(self):
         dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- bump the supported release to immutable `v2.0.2` and update all four READMEs, both installers, package metadata, and `/update`
- replace the retired one-shot release job with tag-driven build, provenance, wheel, source-regression, and Windows-installer validation
- extend the clean wheel smoke to verify `/api/auth/session` and honest blocked-task rendering from the installed artifact

## Validation
- `./venv/bin/python scripts/wheel_smoke.py`
- `./venv/bin/python -m unittest tests.test_distribution -v`
- `make test-core` (172 tests, 3 skipped browser-only)
- `make lint`
- `make check`
- `./venv/bin/python scripts/check_docs.py`
- `git diff --check`

Fixes #111