### PR TITLE
fix: filter DeepSeek DSML from web SSE

### DIFF
--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **172 unittest cases**.
+Current repository test count at this snapshot: **173 unittest cases**.
 
 ## Verified surface
 

--- a/main.py
+++ b/main.py
@@ -3712,6 +3712,88 @@ def _is_question(text: str) -> bool:
     return any(phrase in low for phrase in question_phrases)
 
 
+class DeepSeekDSMLFilter:
+    """Remove DeepSeek V4 tool-call markup without buffering plain prose."""
+
+    _OPEN_RE = re.compile(
+        r"<(?P<marker>｜DSML｜|\|DSML\|)"
+        r"(?P<kind>tool_calls|function_calls|toolcalls|invoke|parameter)\b[^>]*>",
+        re.IGNORECASE,
+    )
+    _STARTS = ("<｜DSML｜", "<|DSML|", "｜｜DSML｜｜", "||DSML||")
+    _PLAIN_MARKER = re.compile(r"｜｜DSML｜｜|\|\|DSML\|\|")
+
+    def __init__(self) -> None:
+        self._buffer = ""
+
+    @classmethod
+    def _partial_suffix_length(cls, value: str) -> int:
+        prefixes = {
+            start[:length]
+            for start in cls._STARTS
+            for length in range(1, len(start) + 1)
+        }
+        for length in range(min(len(value), max(map(len, cls._STARTS))), 0, -1):
+            if value[-length:] in prefixes:
+                return length
+        return 0
+
+    @classmethod
+    def _close_for(cls, match: re.Match[str]) -> str:
+        return f"</{match.group('marker')}{match.group('kind')}>"
+
+    def feed(self, chunk: str = "", *, final: bool = False) -> str:
+        self._buffer += str(chunk or "")
+        output: list[str] = []
+        while self._buffer:
+            match = self._OPEN_RE.search(self._buffer)
+            plain_marker = self._PLAIN_MARKER.search(self._buffer)
+            starts = [item for item in (match, plain_marker) if item is not None]
+            if not starts:
+                if final:
+                    output.append(self._buffer)
+                    self._buffer = ""
+                else:
+                    keep = self._partial_suffix_length(self._buffer)
+                    safe_end = len(self._buffer) - keep
+                    if safe_end:
+                        output.append(self._buffer[:safe_end])
+                        self._buffer = self._buffer[safe_end:]
+                break
+
+            start = min(item.start() for item in starts)
+            if start:
+                output.append(self._buffer[:start])
+                self._buffer = self._buffer[start:]
+                continue
+
+            if plain_marker is not None and plain_marker.start() == 0 and (
+                    match is None or plain_marker.start() <= match.start()):
+                marker = plain_marker.group(0)
+                end = self._buffer.find(marker, len(marker))
+                if end < 0:
+                    self._buffer = "" if final else self._buffer
+                    break
+                self._buffer = self._buffer[end + len(marker):]
+                continue
+
+            # A complete DSML opening tag is present.  Drop it and everything
+            # through its matching close; an incomplete block is held until
+            # the next provider delta (or discarded at the final boundary).
+            match = self._OPEN_RE.match(self._buffer)
+            if match is None:
+                if final:
+                    self._buffer = ""
+                break
+            close = self._close_for(match)
+            end = self._buffer.find(close, match.end())
+            if end < 0:
+                self._buffer = "" if final else self._buffer
+                break
+            self._buffer = self._buffer[end + len(close):]
+        return "".join(output)
+
+
 def _clean_final_response(text: str) -> str:
     """Return only user-facing prose from one model response.
 
@@ -3719,7 +3801,7 @@ def _clean_final_response(text: str) -> str:
     are useful in the next model prompt, but must never become the final
     answer merely because the turn stopped after a tool call.
     """
-    cleaned = str(text or "").strip()
+    cleaned = DeepSeekDSMLFilter().feed(str(text or ""), final=True).strip()
     if not cleaned:
         return ""
     # Remove fenced protocol blocks first.  The model's JSON may contain

--- a/server.py
+++ b/server.py
@@ -403,6 +403,9 @@ def _run_session_chat(session: dict[str, Any], message: str) -> str:
             reply = (_agent._chat_turn(message, clear_tasks=True, profile=profile, memory_context=memory_context)
                      if profile != "auto" else _agent._chat_turn(message, clear_tasks=True,
                                                                   memory_context=memory_context))
+            # The web boundary must never persist provider control syntax even
+            # when a provider or test adapter returns an unclean final string.
+            reply = _agent._clean_final_response(reply)
             session["last_learning_run"] = _agent._last_learning_run
             _agent.short_term_memory.extend([
                 {"role": "user", "content": message},
@@ -955,23 +958,28 @@ async def api_chat_stream(request: Request):
         def __init__(self, sink):
             self.sink = sink
             self.buffer = ""
+            self.dsml = _agent.DeepSeekDSMLFilter()
+
+        def _emit_content(self, chunk: str) -> None:
+            self.buffer += chunk
+            candidate = self.buffer.lstrip()
+            lowered = candidate.lower()
+            if candidate and (
+                any(prefix.lower().startswith(lowered) for prefix in self.prefixes)
+                or any(lowered.startswith(prefix.lower()) for prefix in self.prefixes)
+            ):
+                return
+            if self.buffer:
+                self.sink({"event": "content", "chunk": self.buffer})
+                self.buffer = ""
 
         def __call__(self, event: dict[str, Any]) -> None:
             kind = event.get("event")
             if kind == "content":
-                self.buffer += str(event.get("chunk", ""))
-                candidate = self.buffer.lstrip()
-                lowered = candidate.lower()
-                if candidate and (
-                    any(prefix.lower().startswith(lowered) for prefix in self.prefixes)
-                    or any(lowered.startswith(prefix.lower()) for prefix in self.prefixes)
-                ):
-                    return
-                if self.buffer:
-                    self.sink({"event": "content", "chunk": self.buffer})
-                    self.buffer = ""
+                self._emit_content(self.dsml.feed(str(event.get("chunk", ""))))
                 return
             if kind == "model_complete":
+                self._emit_content(self.dsml.feed("", final=True))
                 self._flush()
                 return
             self.sink(event)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -34,6 +34,28 @@ class _DelayedProvider:
         self.completed.set()
 
 
+class _DSMLProvider:
+    config = ProviderConfig(provider="deepseek", model_simple="deepseek-v4-flash")
+
+    def chat_stream(self, _messages, _model=None):
+        # Split both the opening DSML tag and the legacy marker across deltas.
+        yield from (
+            "Visible ✅ ",
+            "<｜DS",
+            "ML｜tool_calls>",
+            '<｜DSML｜invoke name="write_file">',
+            '<｜DSML｜parameter name="path" string="true">README.md</｜DSML｜parameter>',
+            "</｜DSML｜invoke>",
+            "</｜DSML｜tool_calls>",
+            " after ",
+            "｜｜DS",
+            "ML｜｜",
+            "invoke parameter calls",
+            "｜｜DSML｜｜",
+            "done",
+        )
+
+
 class StreamingEndpointTests(unittest.TestCase):
     def test_first_sse_content_arrives_before_provider_stream_completes(self):
         session_id = "stream-timing-regression"
@@ -86,6 +108,62 @@ class StreamingEndpointTests(unittest.TestCase):
         self.assertEqual(payloads[0]["chunk"], " SECOND")
         self.assertEqual(sum(text(item) == "data: [DONE]\n\n" for item in remaining), 1)
         self.assertTrue(provider.completed.is_set())
+
+    def test_deepseek_dsml_is_filtered_from_stream_and_persisted_reply(self):
+        session_id = "stream-dsml-regression"
+        provider = _DSMLProvider()
+
+        async def exercise():
+            response = await server.api_chat_stream(_Request({
+                "message": "check the notes project", "session_id": session_id,
+            }))
+            iterator = response.body_iterator.__aiter__()
+            frames = []
+            try:
+                while True:
+                    frames.append(await asyncio.wait_for(anext(iterator), timeout=2))
+            except StopAsyncIteration:
+                return frames
+
+        with tempfile.TemporaryDirectory(prefix="openkyrozen-dsml-") as directory:
+            memory = MemoryBank(Path(directory) / "state.sqlite3", workspace_id="dsml-test")
+            original_sessions = server._sessions
+            server._sessions = {}
+            try:
+                with (patch.object(server._agent, "memory_bank", memory),
+                      patch.object(server._agent, "llm_provider", provider),
+                      patch.object(server._agent, "DEEPSEEK_MODEL", "deepseek-v4-flash"),
+                      patch.object(server._agent, "_chat_turn", side_effect=lambda message, **_: (
+                          main._call_llm_with_spinner([{"role": "user", "content": message}])
+                      ))):
+                    frames = asyncio.run(exercise())
+            finally:
+                server._sessions = original_sessions
+
+            def text(item):
+                return item.decode() if isinstance(item, bytes) else item
+
+            payloads = []
+            done = 0
+            for frame in frames:
+                value = text(frame)
+                if value == "data: [DONE]\n\n":
+                    done += 1
+                elif value.startswith("data: "):
+                    payloads.append(json.loads(value.split("data: ", 1)[1].splitlines()[0]))
+
+            content = "".join(item["chunk"] for item in payloads if item.get("event") == "content")
+            self.assertEqual(content, "Visible ✅  after done")
+            self.assertNotRegex(content, r"DSML|invoke|parameter|tool_calls|function_calls")
+            assistant_messages = [
+                event["payload"] for event in memory.store.list_events(
+                    "session.message", workspace_id="dsml-test", session_id=session_id,
+                ) if event["payload"].get("role") == "assistant"
+            ]
+            self.assertEqual(assistant_messages[-1]["content"], content)
+            event_names = [item.get("event") for item in payloads]
+            self.assertLess(event_names.index("usage"), event_names.index("completion"))
+            self.assertEqual(done, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- filter split DeepSeek DSML tool-call blocks before Web SSE content reaches clients
- sanitize the Web persistence boundary so assistant history cannot retain provider control syntax
- preserve plain Unicode content and the existing usage/completion/[DONE] ordering

## Validation
- `./venv/bin/python -m unittest tests.test_streaming -v`

Fixes #118