### PR TITLE
fix: filter inline controls from web streams

### DIFF
--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **175 unittest cases**.
+Current repository test count at this snapshot: **176 unittest cases**.
 
 ## Verified surface
 

--- a/main.py
+++ b/main.py
@@ -3737,7 +3737,11 @@ class DeepSeekDSMLFilter:
     _CONTROL_PREFIXES = tuple(
         item[:length].lower()
         for item in ("action:", "thought:", "plan:", "tasklist:", "taskdone:",
-                     "definetool:", "<", "</")
+                     "definetool:", "<invoke", "<parameter", "<calls", "<tool_calls",
+                     "<function_calls", "< invoke", "< parameter", "< calls",
+                     "< tool_calls", "< function_calls", "</invoke", "</parameter",
+                     "</calls", "</tool_calls", "</function_calls", "</ invoke", "</ parameter",
+                     "</ calls", "</ tool_calls", "</ function_calls")
         for length in range(1, len(item) + 1)
     )
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -56,6 +56,25 @@ class _DSMLProvider:
         )
 
 
+class _InlineControlProvider:
+    config = ProviderConfig(provider="deepseek", model_simple="deepseek-v4-flash")
+
+    def chat_stream(self, _messages, _model=None):
+        # Inline and split legacy controls must never reach the browser.  Keep
+        # ordinary words that merely discuss actions and invocation intact.
+        yield from (
+            "Visible progress. ",
+            "Act",
+            "ion: list_dir",
+            '("tests")Action: run_cmd',
+            ' "git status" ',
+            "Pl",
+            "an: inspect first",
+            " Thought: internal note ",
+            "The action word and invoke word are ordinary prose.",
+        )
+
+
 class StreamingEndpointTests(unittest.TestCase):
     def test_first_sse_content_arrives_before_provider_stream_completes(self):
         session_id = "stream-timing-regression"
@@ -163,7 +182,56 @@ class StreamingEndpointTests(unittest.TestCase):
             self.assertEqual(assistant_messages[-1]["content"], content)
             event_names = [item.get("event") for item in payloads]
             self.assertLess(event_names.index("usage"), event_names.index("completion"))
-            self.assertEqual(done, 1)
+        self.assertEqual(done, 1)
+
+    def test_inline_controls_are_filtered_before_sse_and_persistence(self):
+        session_id = "stream-inline-control-regression"
+        provider = _InlineControlProvider()
+
+        async def exercise():
+            response = await server.api_chat_stream(_Request({
+                "message": "review the project", "session_id": session_id,
+            }))
+            iterator = response.body_iterator.__aiter__()
+            frames = []
+            try:
+                while True:
+                    frames.append(await asyncio.wait_for(anext(iterator), timeout=2))
+            except StopAsyncIteration:
+                return frames
+
+        with tempfile.TemporaryDirectory(prefix="openkyrozen-inline-control-") as directory:
+            memory = MemoryBank(Path(directory) / "state.sqlite3", workspace_id="inline-control-test")
+            original_sessions = server._sessions
+            server._sessions = {}
+            try:
+                with (patch.object(server._agent, "memory_bank", memory),
+                      patch.object(server._agent, "llm_provider", provider),
+                      patch.object(server._agent, "DEEPSEEK_MODEL", "deepseek-v4-flash"),
+                      patch.object(server._agent, "_chat_turn", side_effect=lambda message, **_: (
+                          main._call_llm_with_spinner([{"role": "user", "content": message}])
+                      ))):
+                    frames = asyncio.run(exercise())
+            finally:
+                server._sessions = original_sessions
+
+            def text(item):
+                return item.decode() if isinstance(item, bytes) else item
+
+            payloads = [json.loads(text(frame).split("data: ", 1)[1].splitlines()[0])
+                        for frame in frames
+                        if text(frame).startswith("data: ") and text(frame) != "data: [DONE]\n\n"]
+            content = "".join(item["chunk"] for item in payloads if item.get("event") == "content")
+            self.assertIn("Visible progress.", content)
+            self.assertIn("The action word and invoke word are ordinary prose.", content)
+            self.assertNotRegex(content, r"Action:|Thought:|Plan:|TaskDone:|DefineTool:")
+            self.assertNotRegex(content, r"</?\s*(?:invoke|parameter|calls|tool_calls|function_calls)\b")
+            assistant_messages = [
+                event["payload"] for event in memory.store.list_events(
+                    "session.message", workspace_id="inline-control-test", session_id=session_id,
+                ) if event["payload"].get("role") == "assistant"
+            ]
+            self.assertEqual(assistant_messages[-1]["content"], main._clean_final_response(content))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #122

Reuse the provider control filter at the live SSE projection boundary so inline, concatenated, split, and prose-prefixed legacy controls never reach the browser. Keep ordinary prose and durable persisted assistant content intact.

Validation: streaming endpoint regression, DSML compatibility test, and first-delta timing test.