### PR TITLE
fix: report git branch mutations honestly

### DIFF
--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **176 unittest cases**.
+Current repository test count at this snapshot: **177 unittest cases**.
 
 ## Verified surface
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -16,6 +16,7 @@ from tools import (
     allowed_tool_names,
     git_status,
     git_remote,
+    git_branch,
     read_file,
     read_webpage,
     run_cmd,
@@ -129,6 +130,29 @@ class WorkspaceToolTests(unittest.TestCase):
             git_remote("add origin 'unterminated"),
             "Error: git_remote arguments contain invalid shell quoting.",
         )
+
+    def test_git_branch_mutations_report_success_and_change_repository_state(self):
+        with tempfile.TemporaryDirectory() as directory:
+            repository = Path(directory)
+            subprocess.run(["git", "init", "--quiet", str(repository)], check=True)
+            subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=repository, check=True)
+            subprocess.run(["git", "config", "user.name", "OpenKyrozen Test"], cwd=repository, check=True)
+            (repository / "README.md").write_text("branch test\n", encoding="utf-8")
+            subprocess.run(["git", "add", "README.md"], cwd=repository, check=True)
+            subprocess.run(["git", "commit", "--quiet", "-m", "initial"], cwd=repository, check=True)
+            original_root = tools._WORKSPACE_ROOT
+            set_workspace_root(repository)
+            try:
+                created = git_branch("audit-branch")
+                listed = git_branch("")
+                deleted = git_branch("-d audit-branch")
+                after_delete = git_branch("")
+            finally:
+                set_workspace_root(original_root)
+            self.assertIn("audit-branch", created)
+            self.assertIn("audit-branch", listed)
+            self.assertIn("Deleted branch", deleted)
+            self.assertNotIn("audit-branch", after_delete)
 
     def test_read_webpage_blocks_private_and_reserved_destinations_before_connecting(self):
         class PrivateHandler(BaseHTTPRequestHandler):

--- a/tools.py
+++ b/tools.py
@@ -482,17 +482,31 @@ def git_branch(args: str) -> str:
     """
     try:
         import shlex
+        raw_args = args.strip()
+        try:
+            extra = shlex.split(raw_args) if raw_args else []
+        except ValueError:
+            extra = raw_args.split()
         cmd = ["git", "-C", _git_working_directory(), "branch"]
-        if args.strip():
-            try:
-                extra = shlex.split(args.strip())
-            except ValueError:
-                extra = args.strip().split()
+        if extra:
             cmd.extend(extra)
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
         if result.returncode != 0:
             return f"Git branch failed:\n{result.stderr}"
         out = result.stdout.strip()
+        mutation_flags = {"-d", "-D", "--delete", "-m", "-M", "--move", "-c", "-C", "--copy", "-f", "--force"}
+        mutation = bool(extra and (extra[0] in mutation_flags or not extra[0].startswith("-")))
+        if mutation:
+            targets = [item for item in extra if item != "--" and not item.startswith("-")]
+            if extra[0] in {"-d", "-D", "--delete"}:
+                names = ", ".join(repr(item) for item in targets) or "the requested branch"
+                return f"Deleted branch {names}."
+            if extra[0] in {"-m", "-M", "--move"} and len(targets) >= 2:
+                return f"Renamed branch {targets[-2]!r} to {targets[-1]!r}."
+            if extra[0] in {"-c", "-C", "--copy"} and len(targets) >= 2:
+                return f"Copied branch {targets[-2]!r} to {targets[-1]!r}."
+            name = targets[-1] if targets else "the requested branch"
+            return f"Created branch {name!r}."
         return out if out else "(no branches)"
     except Exception as e:
         return f"Error running git branch: {e}"


### PR DESCRIPTION
Fixes #123

Classify branch mutations separately from listings and return explicit create, delete, rename, or copy messages after Git succeeds. Preserve clear non-zero failures and the empty-list fallback.

Validation: disposable repository regression covers create/list/delete state and output.