### PR TITLE
fix: restore verified preferences on startup

### DIFF
--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **177 unittest cases**.
+Current repository test count at this snapshot: **178 unittest cases**.
 
 ## Verified surface
 

--- a/main.py
+++ b/main.py
@@ -1806,6 +1806,70 @@ _user_preferences: dict[str, Any] = {
     "prefers_tables": False,  # user likes table-format output
     "code_first": False,      # user prefers code before explanation
 }
+_hydrated_preferences: dict[str, Any] = {}
+_preference_scope: tuple[str, str, str | None, str | None] | None = None
+
+
+def _preference_fields(content: str) -> dict[str, Any]:
+    """Parse one durable PREF record without applying untrusted text."""
+    if not str(content).lstrip().upper().startswith("PREF:"):
+        return {}
+    fields: dict[str, Any] = {}
+    for part in str(content).split(":", 1)[1].split(";"):
+        key, separator, value = part.strip().partition("=")
+        if not separator or key not in _user_preferences:
+            continue
+        value = value.strip()
+        if not value:
+            continue
+        if isinstance(_user_preferences[key], bool):
+            if value.lower() not in {"true", "false"}:
+                continue
+            fields[key] = value.lower() == "true"
+        else:
+            fields[key] = value
+    return fields
+
+
+def _restore_user_preferences() -> dict[str, Any]:
+    """Hydrate only active, visible, conflict-free preferences for this scope."""
+    global _preference_scope
+    profile = globals().get("_agent_profile_mode")
+    profile = profile if profile in {"coder", "researcher"} else None
+    scope = (memory_bank.user_id, memory_bank.workspace_id, memory_bank.session_id, profile)
+    if scope != _preference_scope:
+        for key, value in _hydrated_preferences.items():
+            if _user_preferences.get(key) == value:
+                _user_preferences[key] = False if isinstance(value, bool) else ""
+        _hydrated_preferences.clear()
+        _preference_scope = scope
+    try:
+        rows = memory_bank.store.list_memories(
+            kind="preference", status="active", limit=10000,
+            workspace_id=memory_bank.workspace_id, session_id=memory_bank.session_id,
+            user_id=memory_bank.user_id,
+        )
+        if memory_bank.session_id is None:
+            rows = [row for row in rows if not row.get("session_id")]
+        rows = memory_bank.filter_records(
+            rows, profile=profile, authorized_speakers={memory_bank.user_id},
+        )
+    except Exception:
+        return {}
+    candidates: dict[str, set[str]] = {}
+    values: dict[str, Any] = {}
+    for row in rows:
+        for key, value in _preference_fields(row.get("content", "")).items():
+            candidates.setdefault(key, set()).add(repr(value))
+            values[key] = value
+    restored: dict[str, Any] = {}
+    for key, representations in candidates.items():
+        if len(representations) != 1 or _user_preferences.get(key):
+            continue
+        _user_preferences[key] = values[key]
+        _hydrated_preferences[key] = values[key]
+        restored[key] = values[key]
+    return restored
 
 def _detect_user_preferences(user_input: str) -> None:
     """Detect implicit user preferences from their messages."""
@@ -1859,6 +1923,7 @@ def _detect_user_preferences(user_input: str) -> None:
 
 def _build_preference_context() -> str:
     """Build a system message describing known user preferences."""
+    _restore_user_preferences()
     active = [f"{k}={v}" for k, v in _user_preferences.items()
               if v and v not in ("", False)]
     if not active:
@@ -2091,6 +2156,7 @@ def _set_launch_context(context: LaunchContext) -> LaunchContext:
     global _launch_context
     _launch_context = context
     _set_workspace_root(str(context.active_root))
+    _restore_user_preferences()
     return context
 
 
@@ -5662,6 +5728,7 @@ def main() -> None:
                 console.print(f"Agent profile: {_agent_profile_mode}")
             elif parts[1].lower() in {"auto", "coder", "researcher"}:
                 _agent_profile_mode = parts[1].lower()
+                _restore_user_preferences()
                 console.print(f"Agent profile set to {_agent_profile_mode}.")
             else:
                 console.print("Usage: /agent auto|coder|researcher")

--- a/tests/test_learning_dispatcher.py
+++ b/tests/test_learning_dispatcher.py
@@ -1,4 +1,7 @@
 import asyncio
+import os
+import subprocess
+import sys
 import tempfile
 import threading
 import unittest
@@ -21,6 +24,8 @@ class LearningDispatcherTests(unittest.TestCase):
         self.original_cursor = main._learning_dispatch_cursor
         self.original_scan_time = main._last_project_scan_time
         self.original_preferences = dict(main._user_preferences)
+        self.original_hydrated_preferences = dict(main._hydrated_preferences)
+        self.original_preference_scope = main._preference_scope
         self.original_graph = {key: list(value) for key, value in main._knowledge_graph.items()}
         self.original_libraries = set(main._known_libraries)
 
@@ -34,6 +39,9 @@ class LearningDispatcherTests(unittest.TestCase):
         main._last_project_scan_time = self.original_scan_time
         main._user_preferences.clear()
         main._user_preferences.update(self.original_preferences)
+        main._hydrated_preferences.clear()
+        main._hydrated_preferences.update(self.original_hydrated_preferences)
+        main._preference_scope = self.original_preference_scope
         main._knowledge_graph.clear()
         main._knowledge_graph.update({key: list(value) for key, value in self.original_graph.items()})
         main._known_libraries.clear()
@@ -136,6 +144,38 @@ class LearningDispatcherTests(unittest.TestCase):
                 feature_names=tuple(names),
             )
             self.assertEqual([item["feature"] for item in result], [names[0], names[2]])
+
+    def test_verified_preferences_hydrate_in_fresh_runtime_and_prompt(self):
+        with tempfile.TemporaryDirectory(prefix="openkyrozen-preferences-") as directory:
+            root = Path(directory)
+            db_path = root / "state.sqlite3"
+            memory = MemoryBank(db_path, user_id="local", workspace_id="default")
+            engine = main.LearningEngine(memory)
+            self.assertEqual(
+                engine.submit("preference", "PREF: naming_style=snake_case", evidence_id="signal-one")["status"],
+                "candidate",
+            )
+            self.assertEqual(
+                engine.submit("preference", "PREF: naming_style=snake_case", evidence_id="signal-two")["status"],
+                "active",
+            )
+            env = os.environ.copy()
+            env.update({
+                "HOME": str(root), "KYROZEN_DB_PATH": str(db_path),
+                "KYROZEN_DISABLE_VECTOR_INDEX": "1", "KYROZEN_WORKSPACE_ROOT": str(root),
+                "PYTHONPATH": str(Path(__file__).parents[1]),
+            })
+            completed = subprocess.run(
+                [sys.executable, "-c", (
+                    "import main; "
+                    "print(main._build_preference_context()); "
+                    "print('\\n'.join(item['content'] for item in main._build_messages('implement feature')))"
+                )],
+                cwd=Path(__file__).parents[1], env=env, capture_output=True, text=True, check=False,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertIn("naming_style=snake_case", completed.stdout)
+            self.assertIn("Known user preferences", completed.stdout)
 
     def test_feature_failure_is_recorded_without_stopping_the_cycle(self):
         names = main._LEARNING_FEATURE_ORDER[:2]


### PR DESCRIPTION
Fixes #124

Hydrate active preference memories into the automatic prompt context after restart and scope/profile changes. Candidate, conflicting, session-scoped, private, and unauthorized records stay out; explicit in-process preferences remain authoritative.

Validation: fresh subprocess regression persists two independent signals, starts with the same SQLite database, and verifies both preference context and generated prompt.