### PR TITLE
fix: hide prose-prefixed stream controls

### DIFF
--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **180 unittest cases**.
+Current repository test count at this snapshot: **181 unittest cases**.
 
 ## Verified surface
 

--- a/main.py
+++ b/main.py
@@ -3792,6 +3792,12 @@ def _is_question(text: str) -> bool:
     return any(phrase in low for phrase in question_phrases)
 
 
+_ACTION_MARKER_NAMES = tuple(sorted(set(AVAILABLE_TOOLS) | set(TOOL_ALIASES), key=len, reverse=True))
+_ACTION_MARKER_RE = re.compile(
+    r"(?i)(?<![\w])(?P<name>(?:" + "|".join(map(re.escape, _ACTION_MARKER_NAMES)) + r"))\s*:"
+)
+
+
 class DeepSeekDSMLFilter:
     """Remove provider control syntax without buffering ordinary prose."""
 
@@ -3813,14 +3819,17 @@ class DeepSeekDSMLFilter:
         r"</\s*(?P<kind>invoke|parameter|calls|tool_calls|function_calls)\s*>",
         re.IGNORECASE,
     )
+    _ACTION_MARKER_RE = _ACTION_MARKER_RE
     _CONTROL_PREFIXES = tuple(
         item[:length].lower()
-        for item in ("action:", "thought:", "plan:", "tasklist:", "taskdone:",
-                     "definetool:", "<invoke", "<parameter", "<calls", "<tool_calls",
-                     "<function_calls", "< invoke", "< parameter", "< calls",
-                     "< tool_calls", "< function_calls", "</invoke", "</parameter",
-                     "</calls", "</tool_calls", "</function_calls", "</ invoke", "</ parameter",
-                     "</ calls", "</ tool_calls", "</ function_calls")
+        for item in (
+            "action:", "thought:", "plan:", "tasklist:", "taskdone:", "definetool:",
+            "<invoke", "<parameter", "<calls", "<tool_calls", "<function_calls",
+            "< invoke", "< parameter", "< calls", "< tool_calls", "< function_calls",
+            "</invoke", "</parameter", "</calls", "</tool_calls", "</function_calls",
+            "</ invoke", "</ parameter", "</ calls", "</ tool_calls", "</ function_calls",
+            *_ACTION_MARKER_NAMES,
+        )
         for length in range(1, len(item) + 1)
     )
 
@@ -3849,7 +3858,8 @@ class DeepSeekDSMLFilter:
         lowered = value.lower()
         for length in range(min(len(value), max(map(len, cls._CONTROL_PREFIXES))), 0, -1):
             if lowered[-length:] in cls._CONTROL_PREFIXES:
-                if length == 1 and lowered[-1].isalpha() and len(value) > 1 and value[-2].isalnum():
+                start = len(value) - length
+                if start and value[start - 1].isalnum():
                     continue
                 return length
         return 0
@@ -3913,6 +3923,21 @@ class DeepSeekDSMLFilter:
         close = re.compile(rf"</\s*(?:{close_kinds})\s*>", re.IGNORECASE).search(value, match.end())
         return close.end() if close else None
 
+    @staticmethod
+    def _action_marker_end(value: str, match: re.Match[str], *, final: bool) -> int | None:
+        cursor = match.end()
+        while cursor < len(value) and value[cursor] in " \t":
+            cursor += 1
+        if value[cursor:cursor + 3] == "```":
+            close = value.find("```", cursor + 3)
+            if close < 0:
+                return len(value) if final else None
+            return close + 3
+        newline = value.find("\n", cursor)
+        if newline >= 0:
+            return newline + 1
+        return len(value) if final else None
+
     def _filter_control(self, chunk: str, *, final: bool) -> str:
         self._control_buffer += chunk
         output: list[str] = []
@@ -3920,7 +3945,8 @@ class DeepSeekDSMLFilter:
             control = self._CONTROL_RE.search(self._control_buffer)
             generic_open = self._GENERIC_OPEN_RE.search(self._control_buffer)
             generic_close = self._GENERIC_CLOSE_RE.search(self._control_buffer)
-            starts = [item for item in (control, generic_open, generic_close) if item is not None]
+            action_marker = self._ACTION_MARKER_RE.search(self._control_buffer)
+            starts = [item for item in (control, generic_open, generic_close, action_marker) if item is not None]
             if not starts:
                 if final:
                     output.append(self._control_buffer)
@@ -3949,6 +3975,14 @@ class DeepSeekDSMLFilter:
                 end = self._generic_block_end(self._control_buffer, generic_open)
                 if end is None:
                     self._control_buffer = "" if final else self._control_buffer
+                    break
+                self._control_buffer = self._control_buffer[end:]
+                continue
+
+            if action_marker is not None and action_marker.start() == 0 and (
+                    control is None or action_marker.start() <= control.start()):
+                end = self._action_marker_end(self._control_buffer, action_marker, final=final)
+                if end is None:
                     break
                 self._control_buffer = self._control_buffer[end:]
                 continue

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -75,6 +75,22 @@ class _InlineControlProvider:
         )
 
 
+class _ProsePrefixedAliasProvider:
+    config = ProviderConfig(provider="deepseek", model_simple="deepseek-v4-flash")
+
+    def chat_stream(self, _messages, _model=None):
+        # Alias-formatted controls may arrive after prose and across deltas.
+        yield from (
+            "Visible progress. ",
+            "run_",
+            "cmd: ```bash\n",
+            "git status\n",
+            "```",
+            " after the command.\nread_file: README.md\n",
+            "The action word and plan word are ordinary prose.",
+        )
+
+
 class StreamingEndpointTests(unittest.TestCase):
     def test_first_sse_content_arrives_before_provider_stream_completes(self):
         session_id = "stream-timing-regression"
@@ -229,6 +245,55 @@ class StreamingEndpointTests(unittest.TestCase):
             assistant_messages = [
                 event["payload"] for event in memory.store.list_events(
                     "session.message", workspace_id="inline-control-test", session_id=session_id,
+                ) if event["payload"].get("role") == "assistant"
+            ]
+            self.assertEqual(assistant_messages[-1]["content"], main._clean_final_response(content))
+
+    def test_prose_prefixed_alias_controls_are_filtered_before_sse_and_persistence(self):
+        session_id = "stream-prose-alias-regression"
+        provider = _ProsePrefixedAliasProvider()
+
+        async def exercise():
+            response = await server.api_chat_stream(_Request({
+                "message": "review the project", "session_id": session_id,
+            }))
+            iterator = response.body_iterator.__aiter__()
+            frames = []
+            try:
+                while True:
+                    frames.append(await asyncio.wait_for(anext(iterator), timeout=2))
+            except StopAsyncIteration:
+                return frames
+
+        with tempfile.TemporaryDirectory(prefix="openkyrozen-prose-alias-") as directory:
+            memory = MemoryBank(Path(directory) / "state.sqlite3", workspace_id="prose-alias-test")
+            original_sessions = server._sessions
+            server._sessions = {}
+            try:
+                with (patch.object(server._agent, "memory_bank", memory),
+                      patch.object(server._agent, "llm_provider", provider),
+                      patch.object(server._agent, "DEEPSEEK_MODEL", "deepseek-v4-flash"),
+                      patch.object(server._agent, "_chat_turn", side_effect=lambda message, **_: (
+                          main._call_llm_with_spinner([{"role": "user", "content": message}])
+                      ))):
+                    frames = asyncio.run(exercise())
+            finally:
+                server._sessions = original_sessions
+
+            def text(item):
+                return item.decode() if isinstance(item, bytes) else item
+
+            payloads = [json.loads(text(frame).split("data: ", 1)[1].splitlines()[0])
+                        for frame in frames
+                        if text(frame).startswith("data: ") and text(frame) != "data: [DONE]\n\n"]
+            content = "".join(item["chunk"] for item in payloads if item.get("event") == "content")
+            self.assertIn("Visible progress.", content)
+            self.assertIn("The action word and plan word are ordinary prose.", content)
+            self.assertNotRegex(content, r"(?:run_cmd|read_file|bash|shell)\s*:")
+            self.assertNotIn("```", content)
+            assistant_messages = [
+                event["payload"] for event in memory.store.list_events(
+                    "session.message", workspace_id="prose-alias-test", session_id=session_id,
                 ) if event["payload"].get("role") == "assistant"
             ]
             self.assertEqual(assistant_messages[-1]["content"], main._clean_final_response(content))


### PR DESCRIPTION
## Summary\n- scrub known action aliases from incremental SSE projection even after visible prose\n- hold split and fenced alias markers until their bounded control block ends\n- keep persisted assistant content aligned with the live stream\n\n## Validation\n- streaming endpoint regression suite passes\n\nFixes #131