### PR TITLE
docs: align DeepSeek model defaults

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -211,7 +211,7 @@ Web インターフェースは、リアルタイムストリーミング、コ�
          │
          ▼
 ┌─────────────────┐
-│  モデル選択器   │──► deepseek-chat / deepseek-reasoner / gpt-4o / claude / gemini / llama
+│  モデル選択器   │──► deepseek-v4-flash / deepseek-v4-pro / gpt-4o / claude / gemini / llama
 └────────┬────────┘
          │
          ▼
@@ -257,7 +257,7 @@ export KYROZEN_MODEL_COMPLEX=deepseek-v4-pro
 
 | プロバイダー | 簡単なタスク（デフォルト） | 複雑なタスク（デフォルト） |
 |-------------|------------------------|--------------------------|
-| DeepSeek | `deepseek-chat` | `deepseek-reasoner` |
+| DeepSeek | `deepseek-v4-flash` | `deepseek-v4-pro` |
 | OpenAI | `gpt-4o` | `gpt-4o` |
 | Anthropic | `claude-sonnet-4-20250514` | `claude-sonnet-4-20250514` |
 | Google | `gemini-2.5-flash` | `gemini-2.5-pro` |
@@ -614,8 +614,8 @@ def register():
 {
   "provider": "deepseek",
   "api_key": "<暗号化>",
-  "model_simple": "deepseek-chat",
-  "model_complex": "deepseek-reasoner",
+  "model_simple": "deepseek-v4-flash",
+  "model_complex": "deepseek-v4-pro",
   "encrypted": true
 }
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -211,7 +211,7 @@ docker run -p 8000:8000 \
          │
          ▼
 ┌─────────────────┐
-│   모델 선택기   │──► deepseek-chat / deepseek-reasoner / gpt-4o / claude / gemini / llama
+│   모델 선택기   │──► deepseek-v4-flash / deepseek-v4-pro / gpt-4o / claude / gemini / llama
 └────────┬────────┘
          │
          ▼
@@ -257,7 +257,7 @@ export KYROZEN_MODEL_COMPLEX=deepseek-v4-pro
 
 | 제공자 | 간단한 작업 (기본값) | 복잡한 작업 (기본값) |
 |--------|-------------------|---------------------|
-| DeepSeek | `deepseek-chat` | `deepseek-reasoner` |
+| DeepSeek | `deepseek-v4-flash` | `deepseek-v4-pro` |
 | OpenAI | `gpt-4o` | `gpt-4o` |
 | Anthropic | `claude-sonnet-4-20250514` | `claude-sonnet-4-20250514` |
 | Google | `gemini-2.5-flash` | `gemini-2.5-pro` |
@@ -612,8 +612,8 @@ def register():
 {
   "provider": "deepseek",
   "api_key": "<암호화됨>",
-  "model_simple": "deepseek-chat",
-  "model_complex": "deepseek-reasoner",
+  "model_simple": "deepseek-v4-flash",
+  "model_complex": "deepseek-v4-pro",
   "encrypted": true
 }
 ```

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ User Input
          │
          ▼
 ┌─────────────────┐
-│  Model Selector  │──► deepseek-chat / deepseek-reasoner / gpt-4o / claude / gemini / llama
+│  Model Selector  │──► deepseek-v4-flash / deepseek-v4-pro / gpt-4o / claude / gemini / llama
 └────────┬────────┘
          │
          ▼
@@ -860,8 +860,8 @@ example.
 {
   "provider": "deepseek",
   "api_key": "<encrypted>",
-  "model_simple": "deepseek-chat",
-  "model_complex": "deepseek-reasoner",
+  "model_simple": "deepseek-v4-flash",
+  "model_complex": "deepseek-v4-pro",
   "encrypted": true,
   "encryption": "fernet"
 }

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -207,7 +207,7 @@ Web 界面提供暗色主题的聊天 UI，支持实时流式输出、费用追�
          │
          ▼
 ┌─────────────────┐
-│   模型选择器    │──► deepseek-chat / deepseek-reasoner / gpt-4o / claude / gemini / llama
+│   模型选择器    │──► deepseek-v4-flash / deepseek-v4-pro / gpt-4o / claude / gemini / llama
 └────────┬────────┘
          │
          ▼
@@ -253,7 +253,7 @@ export KYROZEN_MODEL_COMPLEX=deepseek-v4-pro
 
 | 服务商 | 简单任务（默认） | 复杂任务（默认） |
 |--------|-----------------|-----------------|
-| DeepSeek | `deepseek-chat` | `deepseek-reasoner` |
+| DeepSeek | `deepseek-v4-flash` | `deepseek-v4-pro` |
 | OpenAI | `gpt-4o` | `gpt-4o` |
 | Anthropic | `claude-sonnet-4-20250514` | `claude-sonnet-4-20250514` |
 | Google | `gemini-2.5-flash` | `gemini-2.5-pro` |
@@ -624,8 +624,8 @@ def register():
 {
   "provider": "deepseek",
   "api_key": "<加密>",
-  "model_simple": "deepseek-chat",
-  "model_complex": "deepseek-reasoner",
+  "model_simple": "deepseek-v4-flash",
+  "model_complex": "deepseek-v4-pro",
   "encrypted": true,
   "encryption": "fernet"
 }

--- a/docs/self-evolution.md
+++ b/docs/self-evolution.md
@@ -9,7 +9,7 @@ Historical verification snapshot: `51be33361422e55e1f2f00c33a0e0f8c56132a91`
 (the post-#54 `main` revision, captured before this #55 documentation-only
 update). Snapshot date: 2026-09-04.
 
-Current repository test count at this snapshot: **187 unittest cases**.
+Current repository test count at this snapshot: **188 unittest cases**.
 
 ## Verified surface
 

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -43,6 +43,7 @@ BENCHMARK_METADATA = (
     "paired_evidence_status: insufficient",
     "public_superiority_claim_supported: false",
 )
+STALE_DEEPSEEK_MODELS = re.compile(r"\bdeepseek-(?:chat|reasoner)\b", re.IGNORECASE)
 
 
 def _command_blocks(text: str) -> list[str]:
@@ -220,6 +221,21 @@ def _check_readme_endpoint_table(path: Path, text: str, routes: set[tuple[str, s
     return errors
 
 
+def _check_provider_defaults(path: Path, text: str, defaults: dict[str, tuple[str, str]]) -> list[str]:
+    """Keep README model examples tied to the provider's current defaults."""
+    simple, complex_model = defaults["deepseek"]
+    errors: list[str] = []
+    if STALE_DEEPSEEK_MODELS.search(text):
+        errors.append(f"{path.name}: README contains a retired DeepSeek model name")
+    simple_match = re.search(r'"model_simple"\s*:\s*"([^"]+)"', text)
+    complex_match = re.search(r'"model_complex"\s*:\s*"([^"]+)"', text)
+    if not simple_match or simple_match.group(1) != simple:
+        errors.append(f"{path.name}: model_simple example must match provider default '{simple}'")
+    if not complex_match or complex_match.group(1) != complex_model:
+        errors.append(f"{path.name}: model_complex example must match provider default '{complex_model}'")
+    return errors
+
+
 def _check_verification_record() -> list[str]:
     if not VERIFICATION_DOC.exists():
         return ["docs/self-evolution.md is missing"]
@@ -254,6 +270,7 @@ def _check_verification_record() -> list[str]:
 def main() -> int:
     expected_inventory = render_inventory()
     import main as agent_main
+    from providers import PROVIDER_DEFAULT_MODELS
 
     runtime_tool_count = len(agent_main.AVAILABLE_TOOLS)
     git_tool_count = sum(name.startswith("git_") for name in agent_main.AVAILABLE_TOOLS)
@@ -268,6 +285,7 @@ def main() -> int:
     errors.extend(_check_verification_record())
     for readme in README_FILES:
         text = readme.read_text(encoding="utf-8")
+        errors.extend(_check_provider_defaults(readme, text, PROVIDER_DEFAULT_MODELS))
         if readme.name == "README.md":
             errors.extend(_check_readme_endpoint_table(readme, text, set(routes)))
         for pattern in STALE_TOOL_PATTERNS:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from providers import (
     FallbackProvider,
     LLMProvider,
+    PROVIDER_DEFAULT_MODELS,
     ProviderConfig,
     _get_encryption_key,
     decrypt_api_key,
@@ -71,6 +72,15 @@ class ProviderConfigTests(unittest.TestCase):
         encrypted = bytes(char ^ key[index % len(key)] for index, char in enumerate(plaintext.encode()))
         ciphertext = base64.b64encode(encrypted).decode()
         self.assertEqual(decrypt_api_key(ciphertext), plaintext)
+
+    def test_readmes_use_current_deepseek_defaults(self):
+        simple, complex_model = PROVIDER_DEFAULT_MODELS["deepseek"]
+        root = Path(__file__).resolve().parents[1]
+        for readme in sorted(root.glob("README*.md")):
+            text = readme.read_text(encoding="utf-8")
+            self.assertNotRegex(text, r"\bdeepseek-(?:chat|reasoner)\b")
+            self.assertIn(f'"model_simple": "{simple}"', text)
+            self.assertIn(f'"model_complex": "{complex_model}"', text)
 
 
 class FallbackModelTests(unittest.TestCase):


### PR DESCRIPTION
Fixes #139

- replace retired DeepSeek model names in all four maintained READMEs
- enforce provider-default parity in the documentation checker
- add regression coverage for every README

Validation: provider README regression; scripts/check_docs.py